### PR TITLE
(TK-367) Add initialization and cleanup hooks

### DIFF
--- a/src/clj/puppetlabs/services/jruby/jruby_agents.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_agents.clj
@@ -63,7 +63,7 @@
   "Flush a single JRubyInstance.  Create a new replacement instance
   and insert it into the specified pool."
   [pool-context :- jruby-schemas/PoolContext
-   instance :- JRubyInstance
+   instance :- jruby-schemas/JRubyInstanceSchema
    new-pool :- jruby-schemas/pool-queue-type
    new-id :- schema/Int
    config :- jruby-schemas/JRubyConfig]
@@ -196,7 +196,7 @@
   "Sends requests to the flush-instance agent to flush the instance and create a new one."
   [pool-context :- jruby-schemas/PoolContext
    pool :- jruby-schemas/pool-queue-type
-   instance :- JRubyInstance]
+   instance :- jruby-schemas/JRubyInstanceSchema]
   ;; We use a separate agent from the main `pool-agent` here, because there is a possibility for deadlock otherwise.
   ;; e.g.:
   ;; 1. A flush-pool request comes in, and we start using the main pool agent to flush the pool.  We do that by

--- a/src/clj/puppetlabs/services/jruby/jruby_agents.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_agents.clj
@@ -38,8 +38,7 @@
   prime-pool!
   "Sequentially fill the pool with new JRubyInstances.  NOTE: this
   function should never be called except by the pool-agent."
-  [{:keys [pool-state] :as pool-context} :- jruby-schemas/PoolContext
-   config :- jruby-schemas/JRubyConfig]
+  [{:keys [pool-state config] :as pool-context} :- jruby-schemas/PoolContext]
   (let [pool (:pool @pool-state)]
     (log/debug (str "Initializing JRubyInstances with the following settings:\n"
                     (ks/pprint-to-string config)))
@@ -173,8 +172,8 @@
   send-prime-pool! :- jruby-schemas/JRubyPoolAgent
   "Sends a request to the agent to prime the pool using the given pool context."
   [pool-context :- jruby-schemas/PoolContext]
-  (let [{:keys [pool-agent config]} pool-context]
-    (send-agent pool-agent #(prime-pool! pool-context config))))
+  (let [{:keys [pool-agent]} pool-context]
+    (send-agent pool-agent #(prime-pool! pool-context))))
 
 (schema/defn ^:always-validate
   send-flush-and-repopulate-pool! :- jruby-schemas/JRubyPoolAgent

--- a/src/clj/puppetlabs/services/jruby/jruby_agents.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_agents.clj
@@ -65,8 +65,8 @@
    new-pool :- jruby-schemas/pool-queue-type
    new-id :- schema/Int
    config :- jruby-schemas/JRubyConfig]
-  (let [shutdown-fn (get-in pool-context [:config :lifecycle :shutdown])]
-    (jruby-internal/cleanup-pool-instance! instance shutdown-fn)
+  (let [cleanup-fn (get-in pool-context [:config :lifecycle :cleanup])]
+    (jruby-internal/cleanup-pool-instance! instance cleanup-fn)
     (jruby-internal/create-pool-instance! new-pool new-id config
                                           (partial send-flush-instance! pool-context))))
 
@@ -89,7 +89,7 @@
         new-pool (:pool new-pool-state)
         old-pool (:pool old-pool-state)
         old-pool-size (:size old-pool-state)
-        shutdown-fn (get-in config [:lifecycle :shutdown])]
+        cleanup-fn (get-in config [:lifecycle :cleanup])]
     (log/info "Replacing old JRuby pool with new instance.")
     (reset! pool-state new-pool-state)
     (log/info "Swapped JRuby pools, beginning cleanup of old pool.")
@@ -100,7 +100,7 @@
                         jruby-internal/borrow-without-timeout-fn
                         old-pool)]
           (try
-            (jruby-internal/cleanup-pool-instance! instance shutdown-fn)
+            (jruby-internal/cleanup-pool-instance! instance cleanup-fn)
             (when refill?
               (jruby-internal/create-pool-instance! new-pool id config
                                                     (partial send-flush-instance! pool-context))

--- a/src/clj/puppetlabs/services/jruby/jruby_agents.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_agents.clj
@@ -61,7 +61,7 @@
   "Flush a single JRubyInstance.  Create a new replacement instance
   and insert it into the specified pool."
   [pool-context :- jruby-schemas/PoolContext
-   instance :- jruby-schemas/JRubyInstanceSchema
+   instance :- JRubyInstance
    new-pool :- jruby-schemas/pool-queue-type
    new-id :- schema/Int
    config :- jruby-schemas/JRubyConfig]
@@ -193,7 +193,7 @@
   "Sends requests to the flush-instance agent to flush the instance and create a new one."
   [pool-context :- jruby-schemas/PoolContext
    pool :- jruby-schemas/pool-queue-type
-   instance :- jruby-schemas/JRubyInstanceSchema]
+   instance :- JRubyInstance]
   ;; We use a separate agent from the main `pool-agent` here, because there is a possibility for deadlock otherwise.
   ;; e.g.:
   ;; 1. A flush-pool request comes in, and we start using the main pool agent to flush the pool.  We do that by

--- a/src/clj/puppetlabs/services/jruby/jruby_core.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_core.clj
@@ -145,11 +145,11 @@
   initialize-lifecycle-fns :- jruby-schemas/LifecycleFns
   [config :- (schema/maybe {schema/Keyword schema/Any})]
   (-> config
-      (update-in [:initialize] #(or % identity))
-      (update-in [:shutdown] #(or % identity))
+      (update-in [:initialize-pool-instance] #(or % identity))
+      (update-in [:cleanup] #(or % identity))
       (update-in [:shutdown-on-error] #(or % (fn [f] (f))))
-      (update-in [:initialize-env-variables]
-                 #(or % jruby-internal/default-initialize-env-variables))))
+      (update-in [:initialize-scripting-container]
+                 #(or % jruby-internal/default-initialize-scripting-container))))
 
 (schema/defn ^:always-validate
   initialize-config :- jruby-schemas/JRubyConfig

--- a/src/clj/puppetlabs/services/jruby/jruby_internal.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_internal.clj
@@ -135,7 +135,7 @@
 (schema/defn ^:always-validate
   cleanup-pool-instance!
   "Cleans up and cleanly terminates a JRubyInstance and removes it from the pool."
-  [{:keys [scripting-container pool] :as instance} :- JRubyInstance
+  [{:keys [scripting-container pool] :as instance} :- jruby-schemas/JRubyInstanceSchema
    shutdown-fn :- IFn]
   (.unregister pool instance)
   (shutdown-fn instance)
@@ -143,7 +143,7 @@
   (log/infof "Cleaned up old JRubyInstance with id %s." (:id instance)))
 
 (schema/defn ^:always-validate
-  create-pool-instance! :- JRubyInstance
+  create-pool-instance! :- jruby-schemas/JRubyInstanceSchema
   "Creates a new JRubyInstance and adds it to the pool."
   [pool :- jruby-schemas/pool-queue-type
    id :- schema/Int

--- a/src/clj/puppetlabs/services/jruby/jruby_internal.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_internal.clj
@@ -95,10 +95,6 @@
   [ruby-load-path :- [schema/Str]
    gem-home :- schema/Str
    compile-mode :- jruby-schemas/SupportedJRubyCompileModes]
-  {:pre [(sequential? ruby-load-path)
-         (every? string? ruby-load-path)
-         (string? gem-home)]
-   :post [(instance? ScriptingContainer %)]}
   (-> (ScriptingContainer. LocalContextScope/SINGLETHREAD)
       (init-jruby-config ruby-load-path gem-home compile-mode)))
 

--- a/src/clj/puppetlabs/services/jruby/jruby_internal.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_internal.clj
@@ -1,11 +1,9 @@
 (ns puppetlabs.services.jruby.jruby-internal
   (:require [schema.core :as schema]
             [puppetlabs.services.jruby.jruby-schemas :as jruby-schemas]
-            [clojure.tools.logging :as log]
-            [puppetlabs.kitchensink.core :as ks])
+            [clojure.tools.logging :as log])
   (:import (com.puppetlabs.jruby_utils.pool JRubyPool)
            (puppetlabs.services.jruby.jruby_schemas JRubyInstance PoisonPill ShutdownPoisonPill)
-           (java.util HashMap)
            (org.jruby CompatVersion Main RubyInstanceConfig RubyInstanceConfig$CompileMode)
            (org.jruby.embed LocalContextScope)
            (java.util.concurrent TimeUnit)
@@ -139,7 +137,7 @@
 (schema/defn ^:always-validate
   cleanup-pool-instance!
   "Cleans up and cleanly terminates a JRubyInstance and removes it from the pool."
-  [{:keys [scripting-container pool] :as instance} :- jruby-schemas/JRubyInstanceSchema
+  [{:keys [scripting-container pool] :as instance} :- JRubyInstance
    cleanup-fn :- IFn]
   (.unregister pool instance)
   (cleanup-fn instance)
@@ -147,7 +145,7 @@
   (log/infof "Cleaned up old JRubyInstance with id %s." (:id instance)))
 
 (schema/defn ^:always-validate
-  create-pool-instance! :- jruby-schemas/JRubyInstanceSchema
+  create-pool-instance! :- JRubyInstance
   "Creates a new JRubyInstance and adds it to the pool."
   [pool :- jruby-schemas/pool-queue-type
    id :- schema/Int

--- a/src/clj/puppetlabs/services/jruby/jruby_internal.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_internal.clj
@@ -49,8 +49,8 @@
   "The environment variables that should be passed to the JRuby interpreters.
 
   We don't want them to read any ruby environment variables, like $RUBY_LIB or
-  anything like that, so pass it an empty environment map - except - Puppet
-  needs HOME and PATH for facter resolution, so leave those, along with GEM_HOME
+  anything like that, so pass it an empty environment map - except - most things
+  needs HOME and PATH to work, so leave those, along with GEM_HOME
   which is necessary for third party extensions that depend on gems.
 
   We need to set the JARS..REQUIRE variables in order to instruct JRuby's
@@ -70,6 +70,14 @@
       "JARS_NO_REQUIRE" "true"
       "JARS_REQUIRE" "false")))
 
+(schema/defn ^:always-validate default-initialize-env-variables :- jruby-schemas/ConfigurableJRuby
+  "Default lifecycle fn for setting environment variables on the
+  scripting container"
+  [scripting-container :- jruby-schemas/ConfigurableJRuby
+   gem-home :- schema/Str]
+  (.setEnvironment scripting-container (managed-environment (get-system-env) gem-home))
+  scripting-container)
+
 (schema/defn ^:always-validate get-compile-mode :- RubyInstanceConfig$CompileMode
   [config-compile-mode :- jruby-schemas/SupportedJRubyCompileModes]
   (case config-compile-mode
@@ -83,32 +91,35 @@
   [jruby-config :- jruby-schemas/ConfigurableJRuby
    ruby-load-path :- [schema/Str]
    gem-home :- schema/Str
-   compile-mode :- jruby-schemas/SupportedJRubyCompileModes]
+   compile-mode :- jruby-schemas/SupportedJRubyCompileModes
+   initialize-env-variables-fn :- IFn]
   (doto jruby-config
     (.setLoadPaths ruby-load-path)
     (.setCompatVersion compat-version)
-    (.setCompileMode (get-compile-mode compile-mode))
-    (.setEnvironment (managed-environment (get-system-env) gem-home))))
+    (.setCompileMode (get-compile-mode compile-mode)))
+  (initialize-env-variables-fn jruby-config gem-home))
 
 (schema/defn ^:always-validate empty-scripting-container :- ScriptingContainer
   "Creates a clean instance of a JRuby `ScriptingContainer` with no code loaded."
   [ruby-load-path :- [schema/Str]
    gem-home :- schema/Str
-   compile-mode :- jruby-schemas/SupportedJRubyCompileModes]
+   compile-mode :- jruby-schemas/SupportedJRubyCompileModes
+   initialize-env-variables-fn :- IFn]
   (-> (ScriptingContainer. LocalContextScope/SINGLETHREAD)
-      (init-jruby-config ruby-load-path gem-home compile-mode)))
+      (init-jruby-config ruby-load-path gem-home compile-mode initialize-env-variables-fn)))
 
 (schema/defn ^:always-validate create-scripting-container :- ScriptingContainer
   "Creates an instance of `org.jruby.embed.ScriptingContainer`."
   [ruby-load-path :- [schema/Str]
    gem-home :- schema/Str
-   compile-mode :- jruby-schemas/SupportedJRubyCompileModes]
+   compile-mode :- jruby-schemas/SupportedJRubyCompileModes
+   initialize-env-variables-fn :- IFn]
   ;; for information on other legal values for `LocalContextScope`, there
   ;; is some documentation available in the JRuby source code; e.g.:
   ;; https://github.com/jruby/jruby/blob/1.7.11/core/src/main/java/org/jruby/embed/LocalContextScope.java#L58
   ;; I'm convinced that this is the safest and most reasonable value
   ;; to use here, but we could potentially explore optimizations in the future.
-  (doto (empty-scripting-container ruby-load-path gem-home compile-mode)
+  (doto (empty-scripting-container ruby-load-path gem-home compile-mode initialize-env-variables-fn)
     ;; As of JRuby 1.7.20 (and the associated 'jruby-openssl' it pulls in),
     ;; we need to explicitly require 'jar-dependencies' so that it is used
     ;; to manage jar loading.  We do this so that we can instruct
@@ -149,7 +160,8 @@
    id :- schema/Int
    config :- jruby-schemas/JRubyConfig
    flush-instance-fn :- IFn
-   init-fn :- IFn]
+   init-fn :- IFn
+   initialize-env-variables-fn :- IFn]
   (let [{:keys [ruby-load-path gem-home compile-mode]} config]
     (when-not ruby-load-path
       (throw (Exception.
@@ -158,7 +170,8 @@
     (let [scripting-container (create-scripting-container
                                ruby-load-path
                                gem-home
-                               compile-mode)]
+                               compile-mode
+                               initialize-env-variables-fn)]
       (let [instance (jruby-schemas/map->JRubyInstance
                       {:pool pool
                        :id id
@@ -168,7 +181,7 @@
                        :scripting-container scripting-container})
             modified-instance (init-fn instance)]
         (.register pool modified-instance)
-        instance))))
+        modified-instance))))
 
 (schema/defn ^:always-validate
   get-pool-state :- jruby-schemas/PoolState
@@ -276,5 +289,6 @@
                       (RubyInstanceConfig.)
                       ruby-load-path
                       gem-home
-                      compile-mode)]
+                      compile-mode
+                      default-initialize-env-variables)]
     (Main. jruby-config)))

--- a/src/clj/puppetlabs/services/jruby/jruby_schemas.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_schemas.clj
@@ -85,7 +85,8 @@
 (def LifecycleFns
   {:initialize IFn
    :shutdown IFn
-   :shutdown-on-error IFn})
+   :shutdown-on-error IFn
+   :initialize-env-variables IFn})
 
 (def PoolContext
   "The data structure that stores all JRuby pools and the original configuration."

--- a/src/clj/puppetlabs/services/jruby/jruby_schemas.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_schemas.clj
@@ -105,6 +105,15 @@
                      (nil? (schema/check JRubyInstanceState @%)))
                'JRubyInstanceState))
 
+(def JRubyInstanceSchema
+  {:pool pool-queue-type
+   :id schema/Int
+   :max-requests schema/Int
+   :flush-instance-fn IFn
+   :state JRubyInstanceStateContainer
+   :scripting-container ScriptingContainer
+   schema/Keyword schema/Any})
+
 (schema/defrecord JRubyInstance
   [pool :- pool-queue-type
    id :- schema/Int

--- a/src/clj/puppetlabs/services/jruby/jruby_schemas.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_schemas.clj
@@ -40,6 +40,12 @@
   "Schema defining the supported values for the JRuby CompileMode setting."
   (apply schema/enum supported-jruby-compile-modes))
 
+(def LifecycleFns
+  {:initialize IFn
+   :shutdown IFn
+   :shutdown-on-error IFn
+   :initialize-env-variables IFn})
+
 (def JRubyConfig
   "Schema defining the config map for the JRuby pooling functions.
 
@@ -59,7 +65,8 @@
    :compile-mode SupportedJRubyCompileModes
    :borrow-timeout schema/Int
    :max-active-instances schema/Int
-   :max-requests-per-instance schema/Int})
+   :max-requests-per-instance schema/Int
+   :lifecycle LifecycleFns})
 
 (def JRubyPoolAgent
   "An agent configured for use in managing JRuby pools"
@@ -82,19 +89,12 @@
                      (nil? (schema/check PoolState @%)))
                'PoolStateContainer))
 
-(def LifecycleFns
-  {:initialize IFn
-   :shutdown IFn
-   :shutdown-on-error IFn
-   :initialize-env-variables IFn})
-
 (def PoolContext
   "The data structure that stores all JRuby pools and the original configuration."
   {:config                JRubyConfig
    :pool-agent            JRubyPoolAgent
    :flush-instance-agent  JRubyPoolAgent
-   :pool-state            PoolStateContainer
-   :lifecycle LifecycleFns})
+   :pool-state            PoolStateContainer})
 
 (def JRubyInstanceState
   "State metadata for an individual JRubyInstance"

--- a/src/clj/puppetlabs/services/jruby/jruby_schemas.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_schemas.clj
@@ -82,12 +82,18 @@
                      (nil? (schema/check PoolState @%)))
                'PoolStateContainer))
 
+(def LifecycleFns
+  {:initialize IFn
+   :shutdown IFn
+   :shutdown-on-error IFn})
+
 (def PoolContext
   "The data structure that stores all JRuby pools and the original configuration."
   {:config                JRubyConfig
    :pool-agent            JRubyPoolAgent
    :flush-instance-agent  JRubyPoolAgent
-   :pool-state            PoolStateContainer})
+   :pool-state            PoolStateContainer
+   :lifecycle LifecycleFns})
 
 (def JRubyInstanceState
   "State metadata for an individual JRubyInstance"
@@ -105,13 +111,7 @@
    max-requests :- schema/Int
    flush-instance-fn :- IFn
    state :- JRubyInstanceStateContainer
-   scripting-container :- ScriptingContainer]
-  Object
-  (toString [this] (format "%s@%s {:id %s :state (Atom: %s)}"
-                           (.getName JRubyInstance)
-                           (Integer/toHexString (.hashCode this))
-                           id
-                           @state)))
+   scripting-container :- ScriptingContainer])
 
 (defn jruby-instance?
   [x]

--- a/src/clj/puppetlabs/services/jruby/jruby_schemas.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_schemas.clj
@@ -41,10 +41,10 @@
   (apply schema/enum supported-jruby-compile-modes))
 
 (def LifecycleFns
-  {:initialize IFn
-   :shutdown IFn
+  {:initialize-pool-instance IFn
+   :cleanup IFn
    :shutdown-on-error IFn
-   :initialize-env-variables IFn})
+   :initialize-scripting-container IFn})
 
 (def JRubyConfig
   "Schema defining the config map for the JRuby pooling functions.

--- a/src/clj/puppetlabs/services/jruby/jruby_schemas.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_schemas.clj
@@ -106,22 +106,14 @@
                      (nil? (schema/check JRubyInstanceState @%)))
                'JRubyInstanceState))
 
-(def JRubyInstanceSchema
-  {:pool pool-queue-type
-   :id schema/Int
-   :max-requests schema/Int
-   :flush-instance-fn IFn
-   :state JRubyInstanceStateContainer
-   :scripting-container ScriptingContainer
-   schema/Keyword schema/Any})
-
 (schema/defrecord JRubyInstance
   [pool :- pool-queue-type
    id :- schema/Int
    max-requests :- schema/Int
    flush-instance-fn :- IFn
    state :- JRubyInstanceStateContainer
-   scripting-container :- ScriptingContainer])
+   scripting-container :- ScriptingContainer]
+  {schema/Keyword schema/Any})
 
 (defn jruby-instance?
   [x]

--- a/src/clj/puppetlabs/services/jruby/jruby_service.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_service.clj
@@ -21,10 +21,12 @@
                            [:ShutdownService shutdown-on-error]]
   (init
     [this context]
-    (let [lifecycle-fns (-> (get-in (get-config) [:jruby :lifecycle-fns])
+    (let [config (core/initialize-config (get-config))
+          lifecycle-fns (-> (get-in (get-config) [:jruby :lifecycle-fns])
                             (update-in [:initialize] #(or % identity))
-                            (update-in [:shutdown] #(or % identity)))
-          config (core/initialize-config (get-config))
+                            (update-in [:shutdown] #(or % identity))
+                            (update-in [:initialize-env-variables]
+                                       #(or % jruby-internal/default-initialize-env-variables)))
           service-id (tk-services/service-id this)
           agent-shutdown-fn (partial shutdown-on-error service-id)]
       (core/verify-config-found! config)

--- a/src/clj/puppetlabs/services/jruby/jruby_service.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_service.clj
@@ -6,8 +6,7 @@
             [puppetlabs.trapperkeeper.services :as tk-services]
             [puppetlabs.services.protocols.jruby :as jruby]
             [slingshot.slingshot :as sling]
-            [puppetlabs.services.jruby.jruby-schemas :as jruby-schemas]
-            [puppetlabs.services.jruby.jruby-internal :as jruby-internal]))
+            [puppetlabs.services.jruby.jruby-schemas :as jruby-schemas]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Public

--- a/src/clj/puppetlabs/services/jruby/jruby_service.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_service.clj
@@ -11,9 +11,6 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Public
 
-;; This service uses TK's normal config service instead of the
-;; PuppetServerConfigService.  This is because that service depends on this one.
-
 (trapperkeeper/defservice jruby-pooled-service
                           jruby/JRubyService
                           [[:ConfigService get-config]
@@ -26,7 +23,6 @@
           config (core/initialize-config (assoc-in initial-config
                                                    [:jruby :lifecycle :shutdown-on-error]
                                                    agent-shutdown-fn))]
-      (core/verify-config-found! config)
       (log/info "Initializing the JRuby service")
       (let [pool-context (core/create-pool-context config)]
         (jruby-agents/send-prime-pool! pool-context)

--- a/test/integration/puppetlabs/services/jruby/jruby_internal_test.clj
+++ b/test/integration/puppetlabs/services/jruby/jruby_internal_test.clj
@@ -31,7 +31,7 @@
     (let [pool (JRubyPool. 1)
           config (jruby-testutils/jruby-config
                   {:compile-mode :jit})
-          instance (jruby-internal/create-pool-instance! pool 0 config #())
+          instance (jruby-internal/create-pool-instance! pool 0 config #() identity)
           container (:scripting-container instance)]
       (try
         (= RubyInstanceConfig$CompileMode/JIT

--- a/test/integration/puppetlabs/services/jruby/jruby_internal_test.clj
+++ b/test/integration/puppetlabs/services/jruby/jruby_internal_test.clj
@@ -31,11 +31,10 @@
     (let [pool (JRubyPool. 1)
           config (jruby-testutils/jruby-config
                   {:compile-mode :jit})
-          instance (jruby-internal/create-pool-instance! pool 0 config #() identity
-                                                         jruby-internal/default-initialize-env-variables)
+          instance (jruby-internal/create-pool-instance! pool 0 config #())
           container (:scripting-container instance)]
       (try
-        (= RubyInstanceConfig$CompileMode/JIT
-           (.getCompileMode container))
+        (is (= RubyInstanceConfig$CompileMode/JIT
+            (.getCompileMode container)))
         (finally
           (.terminate container))))))

--- a/test/integration/puppetlabs/services/jruby/jruby_internal_test.clj
+++ b/test/integration/puppetlabs/services/jruby/jruby_internal_test.clj
@@ -31,7 +31,8 @@
     (let [pool (JRubyPool. 1)
           config (jruby-testutils/jruby-config
                   {:compile-mode :jit})
-          instance (jruby-internal/create-pool-instance! pool 0 config #() identity)
+          instance (jruby-internal/create-pool-instance! pool 0 config #() identity
+                                                         jruby-internal/default-initialize-env-variables)
           container (:scripting-container instance)]
       (try
         (= RubyInstanceConfig$CompileMode/JIT

--- a/test/integration/puppetlabs/services/jruby/jruby_locking_test.clj
+++ b/test/integration/puppetlabs/services/jruby/jruby_locking_test.clj
@@ -8,7 +8,6 @@
             [puppetlabs.trapperkeeper.testutils.bootstrap :as tk-bootstrap]
             [puppetlabs.trapperkeeper.core :as tk]))
 
-(use-fixtures :each jruby-testutils/mock-pool-instance-fixture)
 (use-fixtures :once schema-test/validate-schemas)
 
 (defn jruby-service-test-config

--- a/test/integration/puppetlabs/services/jruby/jruby_pool_int_test.clj
+++ b/test/integration/puppetlabs/services/jruby/jruby_pool_int_test.clj
@@ -326,8 +326,8 @@
 
 (deftest initialization-and-cleanup-hooks-test
   (testing "custom initialization and cleanup callbacks get called appropriately"
-    (let [lifecycle-fns {:initialize (fn [instance] (assoc instance :foo "FOO"))
-                         :shutdown (fn [instance] (log/error "Terminating" (:foo instance)))}
+    (let [lifecycle-fns {:initialize-pool-instance (fn [instance] (assoc instance :foo "FOO"))
+                         :cleanup (fn [instance] (log/error "Terminating" (:foo instance)))}
           config (assoc-in (jruby-testutils/jruby-tk-config
                             (jruby-testutils/jruby-config
                              {:max-active-instances 1
@@ -354,12 +354,12 @@
           (await (get-in context [:pool-context :pool-agent]))
           (is (logged? #"Terminating FOO"))))))))
 
-(deftest initialize-env-variables-hook-test
-  (testing "can set custom environment variables via :initialize-env-variables hook"
-    (let [lifecycle-fns {:initialize-env-variables (fn [scripting-container gem-home]
-                                                     (.setEnvironment scripting-container
-                                                                      {"CUSTOMENV" "foobar"})
-                                                     scripting-container)}
+(deftest initialize-scripting-container-hook-test
+  (testing "can set custom environment variables via :initialize-scripting-container hook"
+    (let [lifecycle-fns {:initialize-scripting-container (fn [scripting-container gem-home]
+                                                           (.setEnvironment scripting-container
+                                                                            {"CUSTOMENV" "foobar"})
+                                                           scripting-container)}
           config (assoc-in (jruby-testutils/jruby-tk-config
                             (jruby-testutils/jruby-config
                              {:max-active-instances 1

--- a/test/integration/puppetlabs/services/jruby/jruby_pool_int_test.clj
+++ b/test/integration/puppetlabs/services/jruby/jruby_pool_int_test.clj
@@ -336,7 +336,7 @@
                              {:max-active-instances 1
                               :max-requests-per-instance 10
                               :borrow-timeout default-borrow-timeout}))
-                           [:jruby :lifecycle-fns] lifecycle-fns)]
+                           [:jruby :lifecycle] lifecycle-fns)]
       (logutils/with-test-logging
        (tk-testutils/with-app-with-config
         app
@@ -368,7 +368,7 @@
                              {:max-active-instances 1
                               :max-requests-per-instance 10
                               :borrow-timeout default-borrow-timeout}))
-                           [:jruby :lifecycle-fns] lifecycle-fns)]
+                           [:jruby :lifecycle] lifecycle-fns)]
       (tk-testutils/with-app-with-config
        app
        [jruby/jruby-pooled-service]

--- a/test/unit/puppetlabs/services/jruby/jruby_agents_test.clj
+++ b/test/unit/puppetlabs/services/jruby/jruby_agents_test.clj
@@ -106,8 +106,7 @@
 
 (deftest next-instance-id-test
   (let [pool-context (jruby-core/create-pool-context
-                      (jruby-testutils/jruby-config {:max-active-instances 8})
-                      jruby-testutils/create-default-lifecycle-fns)]
+                      (jruby-testutils/jruby-config {:max-active-instances 8}))]
     (testing "next instance id should be based on the pool size"
       (is (= 10 (jruby-agents/next-instance-id 2 pool-context)))
       (is (= 100 (jruby-agents/next-instance-id 92 pool-context))))
@@ -118,11 +117,10 @@
 (deftest custom-termination-test
   (testing "Flushing the pool causes shutdown hook to be called"
     (logutils/with-test-logging
-      (let [config (assoc-in (-> (jruby-testutils/jruby-tk-config
-                                  (jruby-testutils/jruby-config {:max-active-instances 1})))
-                             [:jruby :lifecycle-fns]
-                             {:initialize identity
-                              :shutdown (fn [x] (log/error "Hello from shutdown") x)})]
+     (let [config (assoc-in (jruby-testutils/jruby-tk-config
+                             (jruby-testutils/jruby-config {:max-active-instances 1}))
+                            [:jruby :lifecycle]
+                            {:shutdown (fn [x] (log/error "Hello from shutdown") x)})]
         (tk-testutils/with-app-with-config
          app
          [jruby/jruby-pooled-service]

--- a/test/unit/puppetlabs/services/jruby/jruby_agents_test.clj
+++ b/test/unit/puppetlabs/services/jruby/jruby_agents_test.clj
@@ -18,7 +18,6 @@
            (com.puppetlabs.jruby_utils.pool JRubyPool)))
 
 (use-fixtures :once schema-test/validate-schemas)
-(use-fixtures :each jruby-testutils/mock-pool-instance-fixture)
 
 (def default-services
   [jruby/jruby-pooled-service])

--- a/test/unit/puppetlabs/services/jruby/jruby_agents_test.clj
+++ b/test/unit/puppetlabs/services/jruby/jruby_agents_test.clj
@@ -11,7 +11,9 @@
             [puppetlabs.services.jruby.jruby-schemas :as jruby-schemas]
             [puppetlabs.services.jruby.jruby-internal :as jruby-internal]
             [puppetlabs.services.jruby.jruby-agents :as jruby-agents]
-            [puppetlabs.trapperkeeper.testutils.logging :as logutils])
+            [puppetlabs.trapperkeeper.testutils.logging :as logutils]
+            [puppetlabs.services.jruby.jruby-core :as core]
+            [clojure.tools.logging :as log])
   (:import (puppetlabs.services.jruby.jruby_schemas RetryPoisonPill JRubyInstance)
            (com.puppetlabs.jruby_utils.pool JRubyPool)))
 
@@ -104,8 +106,8 @@
 
 (deftest next-instance-id-test
   (let [pool-context (jruby-core/create-pool-context
-                       (jruby-testutils/jruby-config {:max-active-instances 8})
-                       jruby-testutils/default-shutdown-fn)]
+                      (jruby-testutils/jruby-config {:max-active-instances 8})
+                      jruby-testutils/create-default-lifecycle-fns)]
     (testing "next instance id should be based on the pool size"
       (is (= 10 (jruby-agents/next-instance-id 2 pool-context)))
       (is (= 100 (jruby-agents/next-instance-id 92 pool-context))))
@@ -113,20 +115,21 @@
       (let [id (- Integer/MAX_VALUE 1)]
         (is (= (mod id 8) (jruby-agents/next-instance-id id pool-context)))))))
 
-;; TODO: this test is useless as-is; we need to add a cleanup callback and change
-;; this test to validate that it gets called.
-(deftest master-termination-test
-  (testing "Flushing the pool causes masters to be terminated"
+(deftest custom-termination-test
+  (testing "Flushing the pool causes shutdown hook to be called"
     (logutils/with-test-logging
-      (tk-testutils/with-app-with-config
-        app
-        [jruby/jruby-pooled-service]
-        (-> (jruby-testutils/jruby-tk-config
-             (jruby-testutils/jruby-config {:max-active-instances 1})))
-        (let [jruby-service (tk-app/get-service app :JRubyService)
-              context (tk-services/service-context jruby-service)]
-          (jruby-protocol/flush-jruby-pool! jruby-service)
-          ; wait until the flush is complete
-          (await (get-in context [:pool-context :pool-agent]))
-          ;; TODO: add termination callback, test that it is called?
-          #_(is (logged? #"Terminating Master")))))))
+      (let [config (assoc-in (-> (jruby-testutils/jruby-tk-config
+                                  (jruby-testutils/jruby-config {:max-active-instances 1})))
+                             [:jruby :lifecycle-fns]
+                             {:initialize identity
+                              :shutdown (fn [x] (log/error "Hello from shutdown") x)})]
+        (tk-testutils/with-app-with-config
+         app
+         [jruby/jruby-pooled-service]
+         config
+         (let [jruby-service (tk-app/get-service app :JRubyService)
+               context (tk-services/service-context jruby-service)]
+           (jruby-protocol/flush-jruby-pool! jruby-service)
+           ; wait until the flush is complete
+           (await (get-in context [:pool-context :pool-agent]))
+           (is (logged? #"Hello from shutdown"))))))))

--- a/test/unit/puppetlabs/services/jruby/jruby_agents_test.clj
+++ b/test/unit/puppetlabs/services/jruby/jruby_agents_test.clj
@@ -114,12 +114,12 @@
         (is (= (mod id 8) (jruby-agents/next-instance-id id pool-context)))))))
 
 (deftest custom-termination-test
-  (testing "Flushing the pool causes shutdown hook to be called"
+  (testing "Flushing the pool causes cleanup hook to be called"
     (logutils/with-test-logging
      (let [config (assoc-in (jruby-testutils/jruby-tk-config
                              (jruby-testutils/jruby-config {:max-active-instances 1}))
                             [:jruby :lifecycle]
-                            {:shutdown (fn [x] (log/error "Hello from shutdown") x)})]
+                            {:cleanup (fn [x] (log/error "Hello from cleanup") x)})]
         (tk-testutils/with-app-with-config
          app
          [jruby/jruby-pooled-service]
@@ -129,4 +129,4 @@
            (jruby-protocol/flush-jruby-pool! jruby-service)
            ; wait until the flush is complete
            (await (get-in context [:pool-context :pool-agent]))
-           (is (logged? #"Hello from shutdown"))))))))
+           (is (logged? #"Hello from cleanup"))))))))

--- a/test/unit/puppetlabs/services/jruby/jruby_core_test.clj
+++ b/test/unit/puppetlabs/services/jruby/jruby_core_test.clj
@@ -1,8 +1,6 @@
 (ns puppetlabs.services.jruby.jruby-core-test
   (:require [clojure.test :refer :all]
-            [me.raynes.fs :as fs]
             [schema.test :as schema-test]
-            [puppetlabs.kitchensink.core :as ks]
             [puppetlabs.services.jruby.jruby-core :as jruby-core]
             [puppetlabs.trapperkeeper.testutils.logging :as logutils])
   (:import (java.io ByteArrayOutputStream PrintStream ByteArrayInputStream)))

--- a/test/unit/puppetlabs/services/jruby/jruby_interpreter_test.clj
+++ b/test/unit/puppetlabs/services/jruby/jruby_interpreter_test.clj
@@ -8,7 +8,8 @@
     (let [jruby-interpreter (jruby-internal/create-scripting-container
                               jruby-testutils/ruby-load-path
                               jruby-testutils/gem-home
-                              jruby-testutils/compile-mode)
+                              jruby-testutils/compile-mode
+                              jruby-internal/default-initialize-env-variables)
           jruby-env (.runScriptlet jruby-interpreter "ENV")]
 
       ; $HOME and $PATH are left in by `jruby-env`

--- a/test/unit/puppetlabs/services/jruby/jruby_interpreter_test.clj
+++ b/test/unit/puppetlabs/services/jruby/jruby_interpreter_test.clj
@@ -9,7 +9,7 @@
                               jruby-testutils/ruby-load-path
                               jruby-testutils/gem-home
                               jruby-testutils/compile-mode
-                              jruby-internal/default-initialize-env-variables)
+                              jruby-internal/default-initialize-scripting-container)
           jruby-env (.runScriptlet jruby-interpreter "ENV")]
 
       ; $HOME and $PATH are left in by `jruby-env`

--- a/test/unit/puppetlabs/services/jruby/jruby_interpreter_test.clj
+++ b/test/unit/puppetlabs/services/jruby/jruby_interpreter_test.clj
@@ -6,10 +6,7 @@
 (deftest jruby-env-vars
   (testing "the environment used by the JRuby interpreters"
     (let [jruby-interpreter (jruby-internal/create-scripting-container
-                              jruby-testutils/ruby-load-path
-                              jruby-testutils/gem-home
-                              jruby-testutils/compile-mode
-                              jruby-internal/default-initialize-scripting-container)
+                              (jruby-testutils/jruby-config))
           jruby-env (.runScriptlet jruby-interpreter "ENV")]
 
       ; $HOME and $PATH are left in by `jruby-env`

--- a/test/unit/puppetlabs/services/jruby/jruby_pool_test.clj
+++ b/test/unit/puppetlabs/services/jruby/jruby_pool_test.clj
@@ -54,7 +54,7 @@
              background."
       (is (= (jruby-core/free-instance-count pool) 0)))
 
-    (jruby-agents/prime-pool! pool-context config)
+    (jruby-agents/prime-pool! pool-context)
 
     (testing "Borrowing all instances from a pool while it is being primed and
              returning them."
@@ -106,8 +106,7 @@
         pool-context (jruby-core/create-pool-context config)
         err-msg       (re-pattern "Unable to borrow JRubyInstance from pool")]
    (is (thrown? IllegalStateException (jruby-agents/prime-pool!
-                                       pool-context
-                                       (assoc-in config [:lifecycle :initialize]
+                                       (assoc-in pool-context [:config :lifecycle :initialize]
                                                  (fn [_] (throw (IllegalStateException. "BORK!")))))))
     (testing "borrow and borrow-with-timeout both throw an exception if the pool failed to initialize"
       (is (thrown-with-msg? IllegalStateException
@@ -138,7 +137,7 @@
    (let [config (jruby-testutils/jruby-config {:max-active-instances max-instances
                                                :max-requests-per-instance max-requests})
          pool-context (jruby-core/create-pool-context config)]
-     (jruby-agents/prime-pool! pool-context config)
+     (jruby-agents/prime-pool! pool-context)
      pool-context)))
 
 (deftest flush-jruby-after-max-requests

--- a/test/unit/puppetlabs/services/jruby/jruby_pool_test.clj
+++ b/test/unit/puppetlabs/services/jruby/jruby_pool_test.clj
@@ -8,8 +8,6 @@
             [puppetlabs.services.jruby.jruby-internal :as jruby-internal]
             [puppetlabs.trapperkeeper.testutils.logging :as logutils]))
 
-(use-fixtures :each jruby-testutils/mock-pool-instance-fixture)
-
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Tests
 

--- a/test/unit/puppetlabs/services/jruby/jruby_pool_test.clj
+++ b/test/unit/puppetlabs/services/jruby/jruby_pool_test.clj
@@ -104,7 +104,7 @@
         pool-context (jruby-core/create-pool-context config)
         err-msg       (re-pattern "Unable to borrow JRubyInstance from pool")]
    (is (thrown? IllegalStateException (jruby-agents/prime-pool!
-                                       (assoc-in pool-context [:config :lifecycle :initialize]
+                                       (assoc-in pool-context [:config :lifecycle :initialize-pool-instance]
                                                  (fn [_] (throw (IllegalStateException. "BORK!")))))))
     (testing "borrow and borrow-with-timeout both throw an exception if the pool failed to initialize"
       (is (thrown-with-msg? IllegalStateException

--- a/test/unit/puppetlabs/services/jruby/jruby_service_test.clj
+++ b/test/unit/puppetlabs/services/jruby/jruby_service_test.clj
@@ -3,7 +3,6 @@
             [puppetlabs.services.protocols.jruby :as jruby-protocol]
             [puppetlabs.services.jruby.jruby-testutils :as jruby-testutils]
             [puppetlabs.services.jruby.jruby-service :refer :all]
-            [puppetlabs.kitchensink.core :as ks]
             [puppetlabs.kitchensink.testutils :as ks-testutils]
             [puppetlabs.trapperkeeper.app :as app]
             [puppetlabs.trapperkeeper.core :as tk]
@@ -12,13 +11,10 @@
             [puppetlabs.trapperkeeper.testutils.bootstrap :as bootstrap]
             [puppetlabs.trapperkeeper.testutils.logging :as logging]
             [puppetlabs.services.jruby.jruby-core :as jruby-core]
-            [puppetlabs.services.jruby.jruby-internal :as jruby-internal]
             [puppetlabs.services.jruby.jruby-schemas :as jruby-schemas]
-            [me.raynes.fs :as fs]
             [schema.test :as schema-test])
   (:import (puppetlabs.services.jruby.jruby_schemas JRubyInstance)))
 
-(use-fixtures :each jruby-testutils/mock-pool-instance-fixture)
 (use-fixtures :once schema-test/validate-schemas)
 
 (defn jruby-service-test-config

--- a/test/unit/puppetlabs/services/jruby/jruby_service_test.clj
+++ b/test/unit/puppetlabs/services/jruby/jruby_service_test.clj
@@ -35,7 +35,7 @@
          (bootstrap/with-app-with-config
           app
           default-services
-          (assoc-in (jruby-service-test-config 1) [:jruby :lifecycle :initialize]
+          (assoc-in (jruby-service-test-config 1) [:jruby :lifecycle :initialize-pool-instance]
                     (fn [_] (throw (Exception. "42"))))
           (tk/run-app app))
          (catch Exception e

--- a/test/unit/puppetlabs/services/jruby/jruby_testutils.clj
+++ b/test/unit/puppetlabs/services/jruby/jruby_testutils.clj
@@ -54,14 +54,15 @@
 (def create-default-lifecycle-fns
   {:initialize (fn [x] x)
    :shutdown identity
-   :shutdown-on-error default-shutdown-fn})
+   :shutdown-on-error default-shutdown-fn
+   :initialize-env-variables jruby-internal/default-initialize-env-variables})
 
 (defn create-pool-instance
   ([]
    (create-pool-instance (jruby-config {:max-active-instances 1})))
   ([config]
    (let [pool (jruby-internal/instantiate-free-pool 1)]
-     (jruby-internal/create-pool-instance! pool 1 config default-flush-fn identity))))
+     (jruby-internal/create-pool-instance! pool 1 config default-flush-fn identity identity))))
 
 (schema/defn ^:always-validate
   create-mock-pool-instance :- JRubyInstance
@@ -69,7 +70,8 @@
    id :- schema/Int
    config :- jruby-schemas/JRubyConfig
    flush-instance-fn :- IFn
-   init-fn :- IFn]
+   init-fn :- IFn
+   init-env-vars-fn :- IFn]
   (let [instance (jruby-schemas/map->JRubyInstance
                   {:pool pool
                    :id id

--- a/test/unit/puppetlabs/services/jruby/jruby_testutils.clj
+++ b/test/unit/puppetlabs/services/jruby/jruby_testutils.clj
@@ -4,11 +4,7 @@
             [puppetlabs.services.jruby.jruby-internal :as jruby-internal]
             [puppetlabs.trapperkeeper.app :as tk-app]
             [puppetlabs.trapperkeeper.services :as tk-service]
-            [schema.core :as schema])
-  (:import (org.jruby.embed LocalContextScope)
-           (puppetlabs.services.jruby.jruby_schemas JRubyInstance)
-           (clojure.lang IFn)
-           (com.puppetlabs.jruby_utils.jruby ScriptingContainer)))
+            [schema.core :as schema]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Constants
@@ -53,38 +49,6 @@
   ([config]
    (let [pool (jruby-internal/instantiate-free-pool 1)]
      (jruby-internal/create-pool-instance! pool 1 config default-flush-fn))))
-
-(schema/defn ^:always-validate
-  create-mock-pool-instance :- JRubyInstance
-  [pool :- jruby-schemas/pool-queue-type
-   id :- schema/Int
-   config :- jruby-schemas/JRubyConfig
-   flush-instance-fn :- IFn]
-  (let [instance (jruby-schemas/map->JRubyInstance
-                  {:pool pool
-                   :id id
-                   :max-requests (:max-requests-per-instance config)
-                   :flush-instance-fn flush-instance-fn
-                   :state (atom {:borrow-count 0})
-                   :scripting-container (ScriptingContainer.
-                                         LocalContextScope/SINGLETHREAD)})
-        init-fn (get-in config [:lifecycle :initialize])
-        modified-instance (init-fn instance)]
-    (.register pool modified-instance)
-    modified-instance))
-
-(defn mock-pool-instance-fixture
-  "Test fixture which changes the behavior of the JRubyPool to create
-  mock JRubyInstances."
-  [f]
-  (with-redefs
-    [jruby-internal/create-pool-instance! create-mock-pool-instance]
-    (f)))
-
-(defmacro with-mock-pool-instance-fixture
-  [& body]
-  `(let [f# (fn [] (do ~@body))]
-     (mock-pool-instance-fixture f#)))
 
 (defn drain-pool
   "Drains the JRuby pool and returns each instance in a vector."


### PR DESCRIPTION
Add a lifecycle map to the jruby config that includes hooks for initialization, initialization of environment variables, shutdown, and shutdown-on-error that get called in the appropriate places. Users of this
library will then be able to add their own custom initialization and cleanup logic via this map.