### PR TITLE
(maint) Update maintenance section of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ We use the [Trapperkeeper project on
 JIRA](https://tickets.puppetlabs.com/browse/TK) for tickets on this project,
 although Github issues are welcome too.
 
-## Maintainence
+## Maintenance
 
 Maintainers: Ruth Linehan <ruth@puppet.com>, Jeremy Barlow <jeremy.barlow@puppet.com>, Chris Price <chris@puppet.com>
 
-Tickets: https://tickets.puppetlabs.com/browse/SERVER
+Tickets: https://tickets.puppetlabs.com/browse/TK


### PR DESCRIPTION
Correct spelling of "maintenance". Change where maintenance section says to
file tickets to TK, which matches the "support" section. TK seems more
appropriate than SERVER since this is not a Puppet Server specific library.