### PR TITLE
(SERVER-1375) Adds a pool lock check to pool-lock-supersedes test

### DIFF
--- a/test/unit/puppetlabs/jruby_utils/lockable_pool_test.clj
+++ b/test/unit/puppetlabs/jruby_utils/lockable_pool_test.clj
@@ -235,6 +235,11 @@
       @blocked-borrow-thread-started?
       @lock-thread-started?
       (is (not (realized? blocked-borrow-thread-borrowed?)))
+      (let [start (System/currentTimeMillis)]
+        (while (and (not (.isLocked pool))
+                    (< (- (System/currentTimeMillis) start) 10000))
+          (Thread/yield)))
+      (is (.isLocked pool))
       (is (not (realized? lock-acquired?)))
 
       (return-instances pool instances)


### PR DESCRIPTION
This commit adds some logic to the
pool-lock-supersedes-existing-borrows-test to try to wait until
.isLocked() returns true for a requested lock until the test moves on to
validating that borrow requests are held off by the lock.  Without this
change, it was more likely (although still somewhat rare) for the test
to return instances to the pool before the .lock() request was even
made, leading to borrow requests being granted immediately rather than
being held off by the lock.  Test assertions would fail as a result.

This was cherry-picked from https://github.com/puppetlabs/puppetserver/pull/1104.