### PR TITLE
(TK-377) Rename 'max-requests' to 'max-borrows'

### DIFF
--- a/src/clj/puppetlabs/services/jruby/jruby_agents.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_agents.clj
@@ -199,14 +199,14 @@
   ;; 1. A flush-pool request comes in, and we start using the main pool agent to flush the pool.  We do that by
   ;;    borrowing all of the instances from the pool as they are returned to it, and the agent doesn't return
   ;;    control until it has borrowed the correct number of instances.
-  ;; 2. While that is happening, an individual instance reaches the 'max-requests' value.  This instance will never
+  ;; 2. While that is happening, an individual instance reaches the 'max-borrows' value.  This instance will never
   ;;    be returned to the pool; it is handled by sending a function to an agent, which will flush the individual
   ;;    instance, create a replacement one, and return that to the pool.
   ;;
   ;; If we use the same agent for both of these operations, then step 2 will never begin until step 1 completes, and
-  ;; step 1 will never complete because the `max-requests` instance will never be returned to the pool.
+  ;; step 1 will never complete because the `max-borrows` instance will never be returned to the pool.
   ;;
-  ;; Using a separate agent for the 'max-requests' instance flush alleviates this issue.
+  ;; Using a separate agent for the 'max-borrows' instance flush alleviates this issue.
   (let [{:keys [flush-instance-agent config]} pool-context
         id (next-instance-id (:id instance) pool-context)]
     (send-agent flush-instance-agent #(flush-instance! pool-context instance pool id config))))

--- a/src/clj/puppetlabs/services/jruby/jruby_core.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_core.clj
@@ -160,7 +160,7 @@
       (update-in [:compile-mode] #(keyword (or % default-jruby-compile-mode)))
       (update-in [:borrow-timeout] #(or % default-borrow-timeout))
       (update-in [:max-active-instances] #(or % (default-pool-size (ks/num-cpus))))
-      (update-in [:max-requests-per-instance] #(or % 0))
+      (update-in [:max-borrows-per-instance] #(or % 0))
       (update-in [:lifecycle] initialize-lifecycle-fns)))
 
 (schema/defn ^:always-validate

--- a/src/clj/puppetlabs/services/jruby/jruby_internal.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_internal.clj
@@ -162,7 +162,7 @@
       (let [instance (jruby-schemas/map->JRubyInstance
                       {:pool pool
                        :id id
-                       :max-requests (:max-requests-per-instance config)
+                       :max-borrows (:max-borrows-per-instance config)
                        :flush-instance-fn flush-instance-fn
                        :state (atom {:borrow-count 0})
                        :scripting-container scripting-container})
@@ -249,14 +249,14 @@
   (if (jruby-schemas/jruby-instance? instance)
     (let [new-state (swap! (:state instance)
                            update-in [:borrow-count] inc)
-          {:keys [max-requests flush-instance-fn pool]} instance]
-      (if (and (pos? max-requests)
-               (>= (:borrow-count new-state) max-requests))
+          {:keys [max-borrows flush-instance-fn pool]} instance]
+      (if (and (pos? max-borrows)
+               (>= (:borrow-count new-state) max-borrows))
         (do
           (log/infof (str "Flushing JRubyInstance %s because it has exceeded the "
-                          "maximum number of requests (%s)")
+                          "maximum number of borrows (%s)")
                      (:id instance)
-                     max-requests)
+                     max-borrows)
           (try
             (flush-instance-fn pool instance)
             (finally

--- a/src/clj/puppetlabs/services/jruby/jruby_schemas.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_schemas.clj
@@ -65,7 +65,7 @@
    :compile-mode SupportedJRubyCompileModes
    :borrow-timeout schema/Int
    :max-active-instances schema/Int
-   :max-requests-per-instance schema/Int
+   :max-borrows-per-instance schema/Int
    :lifecycle LifecycleFns})
 
 (def JRubyPoolAgent
@@ -110,7 +110,7 @@
 (schema/defrecord JRubyInstance
   [pool :- pool-queue-type
    id :- schema/Int
-   max-requests :- schema/Int
+   max-borrows :- schema/Int
    flush-instance-fn :- IFn
    state :- JRubyInstanceStateContainer
    scripting-container :- ScriptingContainer]


### PR DESCRIPTION
Previously, the `max-requests` setting was used to determine if/when to flush
a JRuby instance after it had handled a certain number of requests in Puppet
Server. This logic might be useful to other users of this library (not just
Puppet Server), but such users might not actually have "requests" causing
JRubyInstances to be used. This commit renames `max-requests` (the setting and
all internal references) to `max-borrows`, which better reflects what it
actually does.