### PR TITLE
(TK-376) Add :internal key to pool context and instance

### DIFF
--- a/src/clj/puppetlabs/services/jruby/jruby_agents.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_agents.clj
@@ -94,7 +94,7 @@
    new-pool-state :- jruby-schemas/PoolState
    refill? :- schema/Bool]
   (let [{:keys [config]} pool-context
-        pool-state-atom (get-in pool-context [:internal :pool-state])
+        pool-state-atom (jruby-internal/get-pool-state-container pool-context)
         new-pool (:pool new-pool-state)
         old-pool (:pool old-pool-state)
         old-pool-size (:size old-pool-state)

--- a/src/clj/puppetlabs/services/jruby/jruby_agents.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_agents.clj
@@ -20,6 +20,14 @@
       (mod next-id pool-size)
       next-id)))
 
+(schema/defn get-pool-agent :- jruby-schemas/JRubyPoolAgent
+  [pool-context :- jruby-schemas/PoolContext]
+  (get-in pool-context [:internal :pool-agent]))
+
+(schema/defn get-flush-instance-agent :- jruby-schemas/JRubyPoolAgent
+  [pool-context :- jruby-schemas/PoolContext]
+  (get-in pool-context [:internal :flush-instance-agent]))
+
 (schema/defn ^:always-validate
   send-agent :- jruby-schemas/JRubyPoolAgent
   "Utility function; given a JRubyPoolAgent, send the specified function.
@@ -38,8 +46,8 @@
   prime-pool!
   "Sequentially fill the pool with new JRubyInstances.  NOTE: this
   function should never be called except by the pool-agent."
-  [{:keys [pool-state config] :as pool-context} :- jruby-schemas/PoolContext]
-  (let [pool (:pool @pool-state)]
+  [{:keys [config] :as pool-context} :- jruby-schemas/PoolContext]
+  (let [pool (jruby-internal/get-pool pool-context)]
     (log/debug (str "Initializing JRubyInstances with the following settings:\n"
                     (ks/pprint-to-string config)))
     (try
@@ -85,13 +93,14 @@
    old-pool-state :- jruby-schemas/PoolState
    new-pool-state :- jruby-schemas/PoolState
    refill? :- schema/Bool]
-  (let [{:keys [config pool-state]} pool-context
+  (let [{:keys [config]} pool-context
+        pool-state-atom (get-in pool-context [:internal :pool-state])
         new-pool (:pool new-pool-state)
         old-pool (:pool old-pool-state)
         old-pool-size (:size old-pool-state)
         cleanup-fn (get-in config [:lifecycle :cleanup])]
     (log/info "Replacing old JRuby pool with new instance.")
-    (reset! pool-state new-pool-state)
+    (reset! pool-state-atom new-pool-state)
     (log/info "Swapped JRuby pools, beginning cleanup of old pool.")
     (doseq [i (range old-pool-size)]
       (try
@@ -130,10 +139,10 @@
    on-complete :- IDeref]
   (try
     (log/info "Flush request received; creating new JRuby pool.")
-    (let [{:keys [config pool-state]} pool-context
+    (let [{:keys [config]} pool-context
           new-pool-state (jruby-internal/create-pool-from-config config)
           new-pool (:pool new-pool-state)
-          old-pool-state @pool-state
+          old-pool-state (jruby-internal/get-pool-state pool-context)
           old-pool (:pool old-pool-state)
           old-pool-size (:size old-pool-state)]
       (when-not (pool-initialized? old-pool-size old-pool)
@@ -153,9 +162,9 @@
   ;; be queued up and we don't need to worry about race conditions between the
   ;; steps we perform here in the body.
   (log/info "Flush request received; creating new JRuby pool.")
-  (let [{:keys [config pool-state]} pool-context
+  (let [{:keys [config]} pool-context
         new-pool-state (jruby-internal/create-pool-from-config config)
-        old-pool @pool-state]
+        old-pool (jruby-internal/get-pool-state pool-context)]
     (swap-and-drain-pool! pool-context old-pool new-pool-state true)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -172,21 +181,21 @@
   send-prime-pool! :- jruby-schemas/JRubyPoolAgent
   "Sends a request to the agent to prime the pool using the given pool context."
   [pool-context :- jruby-schemas/PoolContext]
-  (let [{:keys [pool-agent]} pool-context]
+  (let [pool-agent (get-pool-agent pool-context)]
     (send-agent pool-agent #(prime-pool! pool-context))))
 
 (schema/defn ^:always-validate
   send-flush-and-repopulate-pool! :- jruby-schemas/JRubyPoolAgent
   "Sends requests to the agent to flush the existing pool and create a new one."
   [pool-context :- jruby-schemas/PoolContext]
-  (send-agent (:pool-agent pool-context) #(flush-and-repopulate-pool! pool-context)))
+  (send-agent (get-pool-agent pool-context) #(flush-and-repopulate-pool! pool-context)))
 
 (schema/defn ^:always-validate
   send-flush-pool-for-shutdown! :- jruby-schemas/JRubyPoolAgent
   "Sends requests to the agent to flush the existing pool to prepare for shutdown."
   [pool-context :- jruby-schemas/PoolContext
    on-complete :- IDeref]
-  (send-agent (:pool-agent pool-context) #(flush-pool-for-shutdown! pool-context on-complete)) )
+  (send-agent (get-pool-agent pool-context) #(flush-pool-for-shutdown! pool-context on-complete)))
 
 (schema/defn ^:always-validate
   send-flush-instance! :- jruby-schemas/JRubyPoolAgent
@@ -207,6 +216,7 @@
   ;; step 1 will never complete because the `max-borrows` instance will never be returned to the pool.
   ;;
   ;; Using a separate agent for the 'max-borrows' instance flush alleviates this issue.
-  (let [{:keys [flush-instance-agent config]} pool-context
+  (let [{:keys [config]} pool-context
+        flush-instance-agent (get-flush-instance-agent pool-context)
         id (next-instance-id (:id instance) pool-context)]
     (send-agent flush-instance-agent #(flush-instance! pool-context instance pool id config))))

--- a/src/clj/puppetlabs/services/jruby/jruby_schemas.clj
+++ b/src/clj/puppetlabs/services/jruby/jruby_schemas.clj
@@ -91,11 +91,11 @@
 
 (def PoolContext
   "The data structure that stores all JRuby pools and the original configuration."
-  {:config                JRubyConfig
-   :pool-agent            JRubyPoolAgent
-   :flush-instance-agent  JRubyPoolAgent
-   :pool-state            PoolStateContainer
-   :event-callbacks       Atom})
+  {:config JRubyConfig
+   :internal {:pool-agent JRubyPoolAgent
+              :flush-instance-agent JRubyPoolAgent
+              :pool-state PoolStateContainer
+              :event-callbacks Atom}})
 
 (def JRubyInstanceState
   "State metadata for an individual JRubyInstance"
@@ -107,12 +107,15 @@
                      (nil? (schema/check JRubyInstanceState @%)))
                'JRubyInstanceState))
 
+(def JRubyPuppetInstanceInternal
+  {:flush-instance-fn IFn
+   :pool pool-queue-type
+   :max-borrows schema/Int
+   :state JRubyInstanceStateContainer})
+
 (schema/defrecord JRubyInstance
-  [pool :- pool-queue-type
+  [internal :- JRubyPuppetInstanceInternal
    id :- schema/Int
-   max-borrows :- schema/Int
-   flush-instance-fn :- IFn
-   state :- JRubyInstanceStateContainer
    scripting-container :- ScriptingContainer]
   {schema/Keyword schema/Any})
 

--- a/test/unit/puppetlabs/services/jruby/jruby_agents_test.clj
+++ b/test/unit/puppetlabs/services/jruby/jruby_agents_test.clj
@@ -32,12 +32,13 @@
                                      (deliver pool-state-swapped true)))]
          ; borrow an instance so we know that the pool is ready
          (jruby-core/with-jruby-instance jruby-instance pool-context :retry-poison-pill-test)
-         (add-watch (:pool-state pool-context) :pool-state-watch pool-state-watch-fn)
+         (add-watch (jruby-internal/get-pool-state-container pool-context)
+                    :pool-state-watch pool-state-watch-fn)
          (jruby-core/flush-pool! pool-context)
          ; wait until we know the new pool has been swapped in
          @pool-state-swapped
          ; wait until the flush is complete
-         (await (:pool-agent pool-context))
+         (await (jruby-agents/get-pool-agent pool-context))
          (let [old-pool-instance (jruby-internal/borrow-from-pool!*
                                   jruby-internal/borrow-without-timeout-fn
                                   old-pool)]
@@ -94,5 +95,5 @@
              pool-context (pool-manager-protocol/create-pool pool-manager-service config)]
          (jruby-core/flush-pool! pool-context)
          ; wait until the flush is complete
-         (await (:pool-agent pool-context))
+         (await (jruby-agents/get-pool-agent pool-context))
          (is (= "Hello from cleanup" (deref cleanup-atom))))))))

--- a/test/unit/puppetlabs/services/jruby/jruby_pool_test.clj
+++ b/test/unit/puppetlabs/services/jruby/jruby_pool_test.clj
@@ -89,7 +89,7 @@
       (let [drain-via   (fn [borrow-fn] (doall (repeatedly pool-size borrow-fn)))
             assoc-count (fn [acc jruby]
                           (assoc acc (:id jruby)
-                                     (:borrow-count @(:state jruby))))
+                                     (:borrow-count (jruby-core/instance-state jruby))))
             get-counts  (fn [jrubies] (reduce assoc-count {} jrubies))]
         (doseq [drain-fn [#(jruby-core/borrow-from-pool pool-context :test [])
                           #(jruby-core/borrow-from-pool-with-timeout pool-context :test [])]]
@@ -192,7 +192,7 @@
   (logutils/with-test-logging
     (let [config (jruby-testutils/jruby-config)
           pool (jruby-core/create-pool-context config)
-          pool-state @(:pool-state pool)]
+          pool-state (jruby-core/get-pool-state pool)]
       (is (= (jruby-core/default-pool-size (ks/num-cpus)) (:size pool-state))))))
 
 (defn jruby-test-config

--- a/test/unit/puppetlabs/services/jruby/jruby_testutils.clj
+++ b/test/unit/puppetlabs/services/jruby/jruby_testutils.clj
@@ -80,8 +80,7 @@
                          tk-service/service-context
                          :pool-context)
         num-jrubies (-> pool-context
-                        :pool-state
-                        deref
+                        jruby-core/get-pool-state
                         :size)]
     (while (< (count (jruby-core/registered-instances pool-context))
               num-jrubies)
@@ -91,8 +90,7 @@
   "Wait for all jrubies to land in the pool"
   [pool-context]
   (let [num-jrubies (-> pool-context
-                        :pool-state
-                        deref
+                        jruby-core/get-pool-state
                         :size)]
     (while (< (count (jruby-core/registered-instances pool-context))
               num-jrubies)


### PR DESCRIPTION
Both the pool context and the instance contain keys that we don't want users
to mess with - such as the pool and flush agents and the `flush-instance-fn`.
This commit moves all keys we want to keep "private" in both the pool context
and the instance underneath an `:internal` key.

For the the pool context, the `:config` key remains public; for the instance,
the `:id` and `:scripting-container` remain public.