### PR TITLE
(maint) Use ringutils

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -16,6 +16,9 @@
   :dependencies [[org.clojure/clojure "1.7.0"]
 
                  ;; begin version conflict resolution dependencies
+                 [cheshire "5.6.1"]
+                 [clj-time "0.11.0"]
+                 [org.slf4j/slf4j-api "1.7.13"]
                  ;; end version conflict resolution dependencies
 
                  [org.jruby/jruby-core "1.7.20.1"
@@ -34,11 +37,13 @@
 
                  [org.clojure/tools.logging "0.3.1"]
                  [me.raynes/fs "1.4.6"]
-                 [prismatic/schema "1.0.4"]
+                 [prismatic/schema "1.1.0"]
+                 [slingshot "0.12.2"]
 
 
                  [puppetlabs/trapperkeeper ~tk-version]
-                 [puppetlabs/kitchensink ~ks-version]]
+                 [puppetlabs/kitchensink ~ks-version]
+                 [puppetlabs/ring-middleware "1.0.0"]]
 
   :deploy-repositories [["releases" {:url "https://clojars.org/repo"
                                      :username :env/clojars_jenkins_username

--- a/test/integration/puppetlabs/services/jruby/jruby_pool_int_test.clj
+++ b/test/integration/puppetlabs/services/jruby/jruby_pool_int_test.clj
@@ -15,10 +15,6 @@
 
 (def test-borrow-timeout 180000)
 
-(defn timed-await
-  [agent]
-  (await-for 240000 agent))
-
 (defn get-stack-trace-for-thread-as-str
   [stack-trace-elements]
   (reduce
@@ -162,7 +158,7 @@
        ;; set a ruby constant in each instance so that we can recognize them
        (is (true? (set-constants-and-verify pool-context 4)))
        (jruby-core/flush-pool! pool-context)
-       (is (true? (timed-await (jruby-agents/get-pool-agent pool-context)))
+       (is (true? (jruby-testutils/timed-await (jruby-agents/get-pool-agent pool-context)))
            (str "timed out waiting for the flush to complete, stack:\n"
                 (get-all-stack-traces-as-str)))
        ;; now the pool is flushed, so the constants should be cleared
@@ -212,7 +208,7 @@
          ;; return the instance
          (jruby-core/return-to-pool instance :hold-instance-while-pool-flush-in-progress-test [])
          ;; wait until the flush is complete
-         (is (true? (timed-await (jruby-agents/get-pool-agent pool-context)))
+         (is (true? (jruby-testutils/timed-await (jruby-agents/get-pool-agent pool-context)))
              (str "timed out waiting for the flush to complete, stack:\n"
                   (get-all-stack-traces-as-str))))
        ;; now the pool is flushed, and the constants should be cleared
@@ -254,7 +250,7 @@
          ;; return the instance
          (jruby-core/return-to-pool instance :hold-instance-while-pool-flush-in-progress-test [])
          ;; wait until the flush is complete
-         (is (true? (timed-await (jruby-agents/get-pool-agent pool-context)))
+         (is (true? (jruby-testutils/timed-await (jruby-agents/get-pool-agent pool-context)))
              (str "timed out waiting for the flush to complete, stack:\n"
                   (get-all-stack-traces-as-str))))
        ;; now the pool is flushed, and the constants should be cleared
@@ -340,7 +336,7 @@
                                     [])
 
          ;; wait until the flush is complete
-         (is (true? (timed-await (jruby-agents/get-pool-agent pool-context)))
+         (is (true? (jruby-testutils/timed-await (jruby-agents/get-pool-agent pool-context)))
              (str "timed out waiting for the flush to complete, stack:\n"
                   (get-all-stack-traces-as-str))))
 
@@ -353,7 +349,7 @@
        ;; the flushing is all done before the server is shut down - since
        ;; that could otherwise cause an annoying error message about the
        ;; pool not being full at shut down to be displayed.
-       (timed-await (jruby-agents/get-flush-instance-agent pool-context))))))
+       (jruby-testutils/timed-await (jruby-agents/get-flush-instance-agent pool-context))))))
 
 (deftest initialization-and-cleanup-hooks-test
   (testing "custom initialization and cleanup callbacks get called appropriately"

--- a/test/unit/puppetlabs/services/jruby/jruby_agents_test.clj
+++ b/test/unit/puppetlabs/services/jruby/jruby_agents_test.clj
@@ -38,7 +38,7 @@
          ; wait until we know the new pool has been swapped in
          @pool-state-swapped
          ; wait until the flush is complete
-         (await (jruby-agents/get-pool-agent pool-context))
+         (jruby-testutils/timed-await (jruby-agents/get-pool-agent pool-context))
          (let [old-pool-instance (jruby-internal/borrow-from-pool!*
                                   jruby-internal/borrow-without-timeout-fn
                                   old-pool)]
@@ -95,5 +95,5 @@
              pool-context (pool-manager-protocol/create-pool pool-manager-service config)]
          (jruby-core/flush-pool! pool-context)
          ; wait until the flush is complete
-         (await (jruby-agents/get-pool-agent pool-context))
+         (jruby-testutils/timed-await (jruby-agents/get-pool-agent pool-context))
          (is (= "Hello from cleanup" (deref cleanup-atom))))))))

--- a/test/unit/puppetlabs/services/jruby/jruby_testutils.clj
+++ b/test/unit/puppetlabs/services/jruby/jruby_testutils.clj
@@ -72,20 +72,6 @@
     (fill-drained-pool jrubies)
     result))
 
-(defn wait-for-jrubies
-  "Wait for all jrubies to land in the JRubyService's pool"
-  [app]
-  (let [pool-context (-> app
-                         (tk-app/get-service :JRubyService)
-                         tk-service/service-context
-                         :pool-context)
-        num-jrubies (-> pool-context
-                        jruby-core/get-pool-state
-                        :size)]
-    (while (< (count (jruby-core/registered-instances pool-context))
-              num-jrubies)
-      (Thread/sleep 100))))
-
 (defn wait-for-jrubies-from-pool-context
   "Wait for all jrubies to land in the pool"
   [pool-context]
@@ -95,3 +81,7 @@
     (while (< (count (jruby-core/registered-instances pool-context))
               num-jrubies)
       (Thread/yield))))
+
+(defn timed-await
+  [agent]
+  (await-for 240000 agent))


### PR DESCRIPTION
Use ringutils middleware to throw a service unavailable error, and standardize
on `:kind` and `:msg` for error keys.

Also bump some dependency versions.