### PR TITLE
(SERVER-584) improve handling of environment vars

### DIFF
--- a/src/clj/puppetlabs/services/jruby_pool_manager/jruby_core.clj
+++ b/src/clj/puppetlabs/services/jruby_pool_manager/jruby_core.clj
@@ -100,12 +100,11 @@
   environment variables to be visible to the Ruby code. This map is by default
   set to {} if the user does not specify it in the configuration file."
   [env :- jruby-schemas/EnvMap
-   gem-home :- schema/Str
    config :- (schema/pred map?)]
   (let [whitelist ["HOME" "PATH"]
         clean-env (select-keys env whitelist)]
     (merge (assoc clean-env
-                  "GEM_HOME" gem-home
+                  "GEM_HOME" (:gem-home config)
                   "JARS_NO_REQUIRE" "true"
                   "JARS_REQUIRE" "false")
            (:environment-vars config))))
@@ -115,7 +114,7 @@
   container. Currently it just sets the environment variables."
   [scripting-container :- jruby-schemas/ConfigurableJRuby
    config :- jruby-schemas/JRubyConfig]
-  (.setEnvironment scripting-container (managed-environment (get-system-env) (:gem-home config) config))
+  (.setEnvironment scripting-container (managed-environment (get-system-env) config))
   scripting-container)
 
 (schema/defn ^:always-validate

--- a/src/clj/puppetlabs/services/jruby_pool_manager/jruby_core.clj
+++ b/src/clj/puppetlabs/services/jruby_pool_manager/jruby_core.clj
@@ -107,7 +107,7 @@
                   "GEM_HOME" (:gem-home config)
                   "JARS_NO_REQUIRE" "true"
                   "JARS_REQUIRE" "false")
-           (:environment-vars config))))
+           (clojure.walk/stringify-keys (:environment-vars config)))))
 
 (schema/defn ^:always-validate default-initialize-scripting-container :- jruby-schemas/ConfigurableJRuby
   "Default lifecycle fn for initializing the settings on the scripting

--- a/src/clj/puppetlabs/services/jruby_pool_manager/jruby_core.clj
+++ b/src/clj/puppetlabs/services/jruby_pool_manager/jruby_core.clj
@@ -94,7 +94,11 @@
   uses. JARS_NO_REQUIRE was the legacy way to turn off jar loading but is
   being phased out in favor of JARS_REQUIRE.  As of JRuby 1.7.20, only
   JARS_NO_REQUIRE is honored.  Setting both of those here for forward
-  compatibility."
+  compatibility.
+
+  We also merge an environment-vars map with the config to allow for whitelisted
+  environment variables to be visible to the Ruby code. This map is by default
+  set to {} if the user does not specify it in the configuration file."
   [env :- jruby-schemas/EnvMap
    gem-home :- schema/Str
    config :- (schema/pred map?)]
@@ -129,12 +133,15 @@
 
 (schema/defn ^:always-validate
   initialize-config :- jruby-schemas/JRubyConfig
+  "Initialize keys with default settings if they are not given a value.
+  The config is validated after these defaults are set."
   [config :- {schema/Keyword schema/Any}]
   (-> config
       (update-in [:compile-mode] #(keyword (or % default-jruby-compile-mode)))
       (update-in [:borrow-timeout] #(or % default-borrow-timeout))
       (update-in [:max-active-instances] #(or % (default-pool-size (ks/num-cpus))))
       (update-in [:max-borrows-per-instance] #(or % 0))
+      (update-in [:environment-vars] #(or % {}))
       (update-in [:lifecycle] initialize-lifecycle-fns)))
 
 (schema/defn register-event-handler

--- a/src/clj/puppetlabs/services/jruby_pool_manager/jruby_core.clj
+++ b/src/clj/puppetlabs/services/jruby_pool_manager/jruby_core.clj
@@ -96,20 +96,22 @@
   JARS_NO_REQUIRE is honored.  Setting both of those here for forward
   compatibility."
   [env :- jruby-schemas/EnvMap
-   gem-home :- schema/Str]
+   gem-home :- schema/Str
+   config :- (schema/pred map?)]
   (let [whitelist ["HOME" "PATH"]
         clean-env (select-keys env whitelist)]
-    (assoc clean-env
-      "GEM_HOME" gem-home
-      "JARS_NO_REQUIRE" "true"
-      "JARS_REQUIRE" "false")))
+    (merge (assoc clean-env
+                  "GEM_HOME" gem-home
+                  "JARS_NO_REQUIRE" "true"
+                  "JARS_REQUIRE" "false")
+           (:environment-vars config))))
 
 (schema/defn ^:always-validate default-initialize-scripting-container :- jruby-schemas/ConfigurableJRuby
   "Default lifecycle fn for initializing the settings on the scripting
   container. Currently it just sets the environment variables."
   [scripting-container :- jruby-schemas/ConfigurableJRuby
    config :- jruby-schemas/JRubyConfig]
-  (.setEnvironment scripting-container (managed-environment (get-system-env) (:gem-home config)))
+  (.setEnvironment scripting-container (managed-environment (get-system-env) (:gem-home config) config))
   scripting-container)
 
 (schema/defn ^:always-validate

--- a/src/clj/puppetlabs/services/jruby_pool_manager/jruby_schemas.clj
+++ b/src/clj/puppetlabs/services/jruby_pool_manager/jruby_schemas.clj
@@ -61,7 +61,8 @@
     * :max-active-instances - The maximum number of JRubyInstances that
         will be pooled.
 
-    * :environment-vars - The whitelisted environment variables to be passed"
+    * :environment-vars - A map of whitelisted environment variables and their values to be
+        whitelisted and visible to any Ruby code."
   {:ruby-load-path [schema/Str]
    :gem-home schema/Str
    :compile-mode SupportedJRubyCompileModes
@@ -69,7 +70,7 @@
    :max-active-instances schema/Int
    :max-borrows-per-instance schema/Int
    :lifecycle LifecycleFns
-   (schema/optional-key :environment-vars) {schema/Str schema/Str}})
+   :environment-vars {schema/Str schema/Str}})
 
 (def JRubyPoolAgent
   "An agent configured for use in managing JRuby pools"

--- a/src/clj/puppetlabs/services/jruby_pool_manager/jruby_schemas.clj
+++ b/src/clj/puppetlabs/services/jruby_pool_manager/jruby_schemas.clj
@@ -59,14 +59,17 @@
         values are `:jit`, `:force`, and `:off`.  Defaults to `:off`.
 
     * :max-active-instances - The maximum number of JRubyInstances that
-        will be pooled."
+        will be pooled.
+
+    * :environment-vars - The whitelisted environment variables to be passed"
   {:ruby-load-path [schema/Str]
    :gem-home schema/Str
    :compile-mode SupportedJRubyCompileModes
    :borrow-timeout schema/Int
    :max-active-instances schema/Int
    :max-borrows-per-instance schema/Int
-   :lifecycle LifecycleFns})
+   :lifecycle LifecycleFns
+   (schema/optional-key :environment-vars) {schema/Str schema/Str}})
 
 (def JRubyPoolAgent
   "An agent configured for use in managing JRuby pools"

--- a/src/clj/puppetlabs/services/jruby_pool_manager/jruby_schemas.clj
+++ b/src/clj/puppetlabs/services/jruby_pool_manager/jruby_schemas.clj
@@ -70,7 +70,7 @@
    :max-active-instances schema/Int
    :max-borrows-per-instance schema/Int
    :lifecycle LifecycleFns
-   :environment-vars {schema/Str schema/Str}})
+   :environment-vars {schema/Keyword schema/Str}})
 
 (def JRubyPoolAgent
   "An agent configured for use in managing JRuby pools"

--- a/test/unit/puppetlabs/services/jruby_pool_manager/jruby_interpreter_test.clj
+++ b/test/unit/puppetlabs/services/jruby_pool_manager/jruby_interpreter_test.clj
@@ -15,7 +15,7 @@
 (deftest jruby-whitelist-env-vars
   (testing "the environment used by the JRuby interpreters"
     (let [jruby-interpreter (jruby-internal/create-scripting-container
-                             (jruby-testutils/jruby-config {:environment-vars {"FOO" "for_jruby"}}))
+                             (jruby-testutils/jruby-config {:environment-vars {:FOO "for_jruby"}}))
           jruby-env (.runScriptlet jruby-interpreter "ENV")]
       (is (= #{"HOME" "PATH" "GEM_HOME" "JARS_NO_REQUIRE" "JARS_REQUIRE" "FOO"}
              (set (keys jruby-env))))

--- a/test/unit/puppetlabs/services/jruby_pool_manager/jruby_interpreter_test.clj
+++ b/test/unit/puppetlabs/services/jruby_pool_manager/jruby_interpreter_test.clj
@@ -12,12 +12,11 @@
       (is (= #{"HOME" "PATH" "GEM_HOME" "JARS_NO_REQUIRE" "JARS_REQUIRE"}
              (set (keys jruby-env)))))))
 
-(deftest jruby-env-vars
+(deftest jruby-whitelist-env-vars
   (testing "the environment used by the JRuby interpreters"
     (let [jruby-interpreter (jruby-internal/create-scripting-container
                              (jruby-testutils/jruby-config {:environment-vars {"FOO" "for_jruby"}}))
           jruby-env (.runScriptlet jruby-interpreter "ENV")]
-                                        ; $HOME and $PATH are left in by `jruby-env`
       (is (= #{"HOME" "PATH" "GEM_HOME" "JARS_NO_REQUIRE" "JARS_REQUIRE" "FOO"}
              (set (keys jruby-env))))
       (is (= (.get jruby-env "FOO") "for_jruby")))))

--- a/test/unit/puppetlabs/services/jruby_pool_manager/jruby_interpreter_test.clj
+++ b/test/unit/puppetlabs/services/jruby_pool_manager/jruby_interpreter_test.clj
@@ -8,7 +8,16 @@
     (let [jruby-interpreter (jruby-internal/create-scripting-container
                               (jruby-testutils/jruby-config))
           jruby-env (.runScriptlet jruby-interpreter "ENV")]
-
       ; $HOME and $PATH are left in by `jruby-env`
       (is (= #{"HOME" "PATH" "GEM_HOME" "JARS_NO_REQUIRE" "JARS_REQUIRE"}
-            (set (keys jruby-env)))))))
+             (set (keys jruby-env)))))))
+
+(deftest jruby-env-vars
+  (testing "the environment used by the JRuby interpreters"
+    (let [jruby-interpreter (jruby-internal/create-scripting-container
+                             (jruby-testutils/jruby-config {:environment-vars {"FOO" "for_jruby"}}))
+          jruby-env (.runScriptlet jruby-interpreter "ENV")]
+                                        ; $HOME and $PATH are left in by `jruby-env`
+      (is (= #{"HOME" "PATH" "GEM_HOME" "JARS_NO_REQUIRE" "JARS_REQUIRE" "FOO"}
+             (set (keys jruby-env))))
+      (is (= (.get jruby-env "FOO") "for_jruby")))))


### PR DESCRIPTION
This PR adds a whitelisting capability to the handling of environment variables. This also adds an `environment-vars` key to the list of accepted keys in JRubyConfig so that this key can be used in a `puppetserver.conf` file. Keys that are added to the new `environment-vars` map will be reachable and visible by any Ruby code. This PR also adds tests to make sure that the environment variables are correctly stored and visible.