### PR TITLE
(SERVER-1408) Update to PL release of JRuby 1.7.26

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -21,18 +21,18 @@
                  [org.slf4j/slf4j-api "1.7.13"]
                  ;; end version conflict resolution dependencies
 
-                 [org.jruby/jruby-core "1.7.20.1"
+                 [puppetlabs.org.jruby/jruby-core "1.7.26-puppetlabs-rc1"
                   :exclusions [com.github.jnr/jffi com.github.jnr/jnr-x86asm]]
                  ;; jffi and jnr-x86asm are explicit dependencies because,
                  ;; in JRuby's poms, they are defined using version ranges,
                  ;; and :pedantic? :abort won't tolerate this.
-                 [com.github.jnr/jffi "1.2.9"]
-                 [com.github.jnr/jffi "1.2.9" :classifier "native"]
+                 [com.github.jnr/jffi "1.2.12"]
+                 [com.github.jnr/jffi "1.2.12" :classifier "native"]
                  [com.github.jnr/jnr-x86asm "1.0.2"]
                  ;; NOTE: jruby-stdlib packages some unexpected things inside
                  ;; of its jar; please read the detailed notes above the
                  ;; 'uberjar-exclusions' example toward the end of this file.
-                 [org.jruby/jruby-stdlib "1.7.20.1"]
+                 [puppetlabs/jruby-stdlib "1.7.26-puppetlabs-1-SNAPSHOT"]
 
 
                  [org.clojure/tools.logging "0.3.1"]

--- a/test/integration/puppetlabs/services/jruby_pool_manager/jruby_pool_int_test.clj
+++ b/test/integration/puppetlabs/services/jruby_pool_manager/jruby_pool_int_test.clj
@@ -403,6 +403,7 @@
                          [])
                scripting-container (:scripting-container instance)
                jruby-env (.runScriptlet scripting-container "ENV")]
+           (.remove jruby-env "RUBY")
            (is (= {"CUSTOMENV" "foobar"} jruby-env))
            (jruby-core/return-to-pool
             instance

--- a/test/unit/puppetlabs/services/jruby_pool_manager/jruby_interpreter_test.clj
+++ b/test/unit/puppetlabs/services/jruby_pool_manager/jruby_interpreter_test.clj
@@ -9,7 +9,7 @@
                               (jruby-testutils/jruby-config))
           jruby-env (.runScriptlet jruby-interpreter "ENV")]
       ; $HOME and $PATH are left in by `jruby-env`
-      (is (= #{"HOME" "PATH" "GEM_HOME" "JARS_NO_REQUIRE" "JARS_REQUIRE"}
+      (is (= #{"HOME" "PATH" "GEM_HOME" "JARS_NO_REQUIRE" "JARS_REQUIRE" "RUBY"}
              (set (keys jruby-env)))))))
 
 (deftest jruby-whitelist-env-vars
@@ -17,6 +17,6 @@
     (let [jruby-interpreter (jruby-internal/create-scripting-container
                              (jruby-testutils/jruby-config {:environment-vars {:FOO "for_jruby"}}))
           jruby-env (.runScriptlet jruby-interpreter "ENV")]
-      (is (= #{"HOME" "PATH" "GEM_HOME" "JARS_NO_REQUIRE" "JARS_REQUIRE" "FOO"}
+      (is (= #{"HOME" "PATH" "GEM_HOME" "JARS_NO_REQUIRE" "JARS_REQUIRE" "FOO" "RUBY"}
              (set (keys jruby-env))))
       (is (= (.get jruby-env "FOO") "for_jruby")))))


### PR DESCRIPTION
This commit updates us to use a PL release of JRuby 1.7.26 that has
been deployed to clojars, as
there are upstream fixes that we really need and it's not clear
when they might be doing their own release.

The commit also updates a few tests, because recent changes in
JRuby introduce a 'RUBY' environment variable into all
ScriptingContainers.