### PR TITLE
(MAINT) Add CHANGELOG.md release notes for 0.2.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+### 0.2.1
+
+This is a maintenance release.
+
+ * Bump dependencies to JRuby 1.7.26.
+
 ### 0.2.0
 
 This is a feature release.


### PR DESCRIPTION
This commit adds release notes to the CHANGELOG.md file for the 0.2.1
release.