### PR TITLE
(TK-398) Fix with-jruby-retry-test race condition

### DIFF
--- a/test/unit/puppetlabs/services/jruby_pool_manager/jruby_testutils.clj
+++ b/test/unit/puppetlabs/services/jruby_pool_manager/jruby_testutils.clj
@@ -34,7 +34,8 @@
   ([options]
    (jruby-core/initialize-config
     (merge {:ruby-load-path ruby-load-path
-            :gem-home gem-home}
+            :gem-home gem-home
+            :borrow-timeout 300000}
            options))))
 
 (def default-flush-fn


### PR DESCRIPTION
This commit adds a borrow to the main service pool in the
`with-jruby-retry-test-via-mock-get-pool` function before any borrows
with intentional retries are attempted.  Previously, without the extra
borrow, the test's use of the `with-redefs` function to switch out the
`get-pool` function could cause pool instances to only be created in
the retry pool and not the main service pool, leading a borrow attempt
made against the main service pool to hang.