### PR TITLE
(SERVER-1412) Add support for `gem-path` config

### DIFF
--- a/src/clj/puppetlabs/services/jruby_pool_manager/impl/jruby_internal.clj
+++ b/src/clj/puppetlabs/services/jruby_pool_manager/impl/jruby_internal.clj
@@ -26,7 +26,7 @@
   [{:keys [gem-path gem-home] :as jruby-config} :- {schema/Keyword schema/Any}]
   (if gem-path
     jruby-config
-    (assoc jruby-config :gem-path gem-home)))
+    (assoc jruby-config :gem-path nil)))
 
 (defn instantiate-free-pool
   "Instantiate a new queue object to use as the pool of free JRuby's."

--- a/src/clj/puppetlabs/services/jruby_pool_manager/impl/jruby_internal.clj
+++ b/src/clj/puppetlabs/services/jruby_pool_manager/impl/jruby_internal.clj
@@ -22,6 +22,12 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Private
 
+(schema/defn ^:always-validate initialize-gem-path :- {schema/Keyword schema/Any}
+  [{:keys [gem-path gem-home] :as jruby-config} :- {schema/Keyword schema/Any}]
+  (if gem-path
+    jruby-config
+    (assoc jruby-config :gem-path gem-home)))
+
 (defn instantiate-free-pool
   "Instantiate a new queue object to use as the pool of free JRuby's."
   [size]

--- a/src/clj/puppetlabs/services/jruby_pool_manager/jruby_core.clj
+++ b/src/clj/puppetlabs/services/jruby_pool_manager/jruby_core.clj
@@ -112,7 +112,6 @@
         clean-env (select-keys env whitelist)]
     (merge (-> (assoc clean-env
                  "GEM_HOME" (:gem-home config)
-
                  "JARS_NO_REQUIRE" "true"
                  "JARS_REQUIRE" "false")
                (add-gem-path config))

--- a/src/clj/puppetlabs/services/jruby_pool_manager/jruby_core.clj
+++ b/src/clj/puppetlabs/services/jruby_pool_manager/jruby_core.clj
@@ -79,6 +79,13 @@
   []
   (into {} (System/getenv)))
 
+(schema/defn ^:always-validate add-gem-path
+  [env :- {schema/Str schema/Str}
+   config :- jruby-schemas/JRubyConfig]
+  (if-let [gem-path (:gem-path config)]
+    (assoc env "GEM_PATH" gem-path)
+    env))
+
 (schema/defn ^:always-validate managed-environment :- jruby-schemas/EnvMap
   "The environment variables that should be passed to the JRuby interpreters.
 
@@ -103,11 +110,12 @@
    config :- jruby-schemas/JRubyConfig]
   (let [whitelist ["HOME" "PATH"]
         clean-env (select-keys env whitelist)]
-    (merge (assoc clean-env
-                  "GEM_HOME" (:gem-home config)
-                  "GEM_PATH"  (:gem-path config)
-                  "JARS_NO_REQUIRE" "true"
-                  "JARS_REQUIRE" "false")
+    (merge (-> (assoc clean-env
+                 "GEM_HOME" (:gem-home config)
+
+                 "JARS_NO_REQUIRE" "true"
+                 "JARS_REQUIRE" "false")
+               (add-gem-path config))
            (clojure.walk/stringify-keys (:environment-vars config)))))
 
 (schema/defn ^:always-validate default-initialize-scripting-container :- jruby-schemas/ConfigurableJRuby

--- a/src/clj/puppetlabs/services/jruby_pool_manager/jruby_schemas.clj
+++ b/src/clj/puppetlabs/services/jruby_pool_manager/jruby_schemas.clj
@@ -53,7 +53,9 @@
 
     * :ruby-load-path - a vector of file paths, containing the locations of ruby source code.
 
-    * :gem-home - The location that JRuby gems are stored
+    * :gem-home - The location that JRuby gems will be installed
+
+    * :gem-path - The full path where JRuby should look for gems
 
     * :compile-mode - The value to use for JRuby's CompileMode setting.  Legal
         values are `:jit`, `:force`, and `:off`.  Defaults to `:off`.

--- a/src/clj/puppetlabs/services/jruby_pool_manager/jruby_schemas.clj
+++ b/src/clj/puppetlabs/services/jruby_pool_manager/jruby_schemas.clj
@@ -65,6 +65,7 @@
         whitelisted and visible to any Ruby code."
   {:ruby-load-path [schema/Str]
    :gem-home schema/Str
+   :gem-path schema/Str
    :compile-mode SupportedJRubyCompileModes
    :borrow-timeout schema/Int
    :max-active-instances schema/Int

--- a/src/clj/puppetlabs/services/jruby_pool_manager/jruby_schemas.clj
+++ b/src/clj/puppetlabs/services/jruby_pool_manager/jruby_schemas.clj
@@ -67,7 +67,7 @@
         whitelisted and visible to any Ruby code."
   {:ruby-load-path [schema/Str]
    :gem-home schema/Str
-   :gem-path schema/Str
+   :gem-path (schema/maybe schema/Str)
    :compile-mode SupportedJRubyCompileModes
    :borrow-timeout schema/Int
    :max-active-instances schema/Int

--- a/test/unit/puppetlabs/services/jruby_pool_manager/jruby_interpreter_test.clj
+++ b/test/unit/puppetlabs/services/jruby_pool_manager/jruby_interpreter_test.clj
@@ -9,7 +9,7 @@
                               (jruby-testutils/jruby-config))
           jruby-env (.runScriptlet jruby-interpreter "ENV")]
       ; $HOME and $PATH are left in by `jruby-env`
-      (is (= #{"HOME" "PATH" "GEM_HOME" "GEM_PATH" "JARS_NO_REQUIRE" "JARS_REQUIRE" "RUBY"}
+      (is (= #{"HOME" "PATH" "GEM_HOME" "JARS_NO_REQUIRE" "JARS_REQUIRE" "RUBY"}
              (set (keys jruby-env)))))))
 
 (deftest jruby-whitelist-env-vars
@@ -17,6 +17,6 @@
     (let [jruby-interpreter (jruby-internal/create-scripting-container
                              (jruby-testutils/jruby-config {:environment-vars {:FOO "for_jruby"}}))
           jruby-env (.runScriptlet jruby-interpreter "ENV")]
-      (is (= #{"HOME" "PATH" "GEM_HOME" "GEM_PATH" "JARS_NO_REQUIRE" "JARS_REQUIRE" "FOO" "RUBY"}
+      (is (= #{"HOME" "PATH" "GEM_HOME" "JARS_NO_REQUIRE" "JARS_REQUIRE" "FOO" "RUBY"}
              (set (keys jruby-env))))
       (is (= (.get jruby-env "FOO") "for_jruby")))))

--- a/test/unit/puppetlabs/services/jruby_pool_manager/jruby_interpreter_test.clj
+++ b/test/unit/puppetlabs/services/jruby_pool_manager/jruby_interpreter_test.clj
@@ -9,7 +9,7 @@
                               (jruby-testutils/jruby-config))
           jruby-env (.runScriptlet jruby-interpreter "ENV")]
       ; $HOME and $PATH are left in by `jruby-env`
-      (is (= #{"HOME" "PATH" "GEM_HOME" "JARS_NO_REQUIRE" "JARS_REQUIRE" "RUBY"}
+      (is (= #{"HOME" "PATH" "GEM_HOME" "GEM_PATH" "JARS_NO_REQUIRE" "JARS_REQUIRE" "RUBY"}
              (set (keys jruby-env)))))))
 
 (deftest jruby-whitelist-env-vars
@@ -17,6 +17,6 @@
     (let [jruby-interpreter (jruby-internal/create-scripting-container
                              (jruby-testutils/jruby-config {:environment-vars {:FOO "for_jruby"}}))
           jruby-env (.runScriptlet jruby-interpreter "ENV")]
-      (is (= #{"HOME" "PATH" "GEM_HOME" "JARS_NO_REQUIRE" "JARS_REQUIRE" "FOO" "RUBY"}
+      (is (= #{"HOME" "PATH" "GEM_HOME" "GEM_PATH" "JARS_NO_REQUIRE" "JARS_REQUIRE" "FOO" "RUBY"}
              (set (keys jruby-env))))
       (is (= (.get jruby-env "FOO") "for_jruby")))))

--- a/test/unit/puppetlabs/services/jruby_pool_manager/jruby_pool_test.clj
+++ b/test/unit/puppetlabs/services/jruby_pool_manager/jruby_pool_test.clj
@@ -46,11 +46,10 @@
                       (assoc :compile-mode "jit")
                       (jruby-core/initialize-config)
                       :compile-mode))))
-    (testing "gem-path is set to gem-home if not specified"
-      (is (= (:gem-home minimal-config)
-             (-> minimal-config
-                 jruby-core/initialize-config
-                 :gem-path))))
+    (testing "gem-path is set to nil if not specified"
+      (is (nil? (-> minimal-config
+                    jruby-core/initialize-config
+                    :gem-path))))
     (testing "gem-path is respected if specified"
       (is (= "/tmp/foo:/dev/null"
              (-> minimal-config

--- a/test/unit/puppetlabs/services/jruby_pool_manager/jruby_pool_test.clj
+++ b/test/unit/puppetlabs/services/jruby_pool_manager/jruby_pool_test.clj
@@ -45,7 +45,18 @@
       (is (= :jit (-> minimal-config
                       (assoc :compile-mode "jit")
                       (jruby-core/initialize-config)
-                      :compile-mode))))))
+                      :compile-mode))))
+    (testing "gem-path is set to gem-home if not specified"
+      (is (= (:gem-home minimal-config)
+             (-> minimal-config
+                 jruby-core/initialize-config
+                 :gem-path))))
+    (testing "gem-path is respected if specified"
+      (is (= "/tmp/foo:/dev/null"
+             (-> minimal-config
+                 (assoc :gem-path "/tmp/foo:/dev/null")
+                 jruby-core/initialize-config
+                 :gem-path))))))
 
 (deftest test-jruby-core-funcs
   (let [pool-size        2


### PR DESCRIPTION
This commit adds support for a `gem-path` configuration setting.
If specified it will be used as the value for the GEM_PATH
environment variable.  If not, GEM_PATH will be set to the same value
as GEM_HOME.

This is in support of SERVER-1412, where the server will pass in a value for this setting that includes a new "vendored" gem directory.  My intent is that Puppet Server will *always* pass in a value for this setting, and will have its own logic for defaulting the value that it uses for that setting.  But as far as the API of this library goes it seemed like this was the best way to build it.  Open to feedback - would be willing to make it a required argument if people thought that was better (that was my original instinct on how to implement this).