### PR TITLE
(SERVER-1585) Add `compat-version` setting

### DIFF
--- a/src/clj/puppetlabs/services/jruby_pool_manager/impl/jruby_internal.clj
+++ b/src/clj/puppetlabs/services/jruby_pool_manager/impl/jruby_internal.clj
@@ -12,14 +12,6 @@
            (com.puppetlabs.jruby_utils.jruby ScriptingContainer)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;;; Definitions
-
-(def compat-version
-  "The JRuby compatibility version to use for all ruby components, e.g. the
-  master service and CLI tools."
-  (CompatVersion/RUBY1_9))
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Private
 
 (schema/defn ^:always-validate initialize-gem-path :- {schema/Keyword schema/Any}
@@ -41,16 +33,24 @@
     :force RubyInstanceConfig$CompileMode/FORCE
     :off RubyInstanceConfig$CompileMode/OFF))
 
+(schema/defn ^:always-validate get-compat-version
+  "Get the JRuby compatibility version to use for all ruby components, e.g. the
+  master service and CLI tools."
+  [compat-version :- jruby-schemas/SupportedJRubyCompatVersions]
+  (case compat-version
+    "1.9" (CompatVersion/RUBY1_9)
+    "2.0" (CompatVersion/RUBY2_0)))
+
 (schema/defn ^:always-validate init-jruby :- jruby-schemas/ConfigurableJRuby
   "Applies configuration to a JRuby... thing.  See comments in `ConfigurableJRuby`
   schema for more details."
   [jruby :- jruby-schemas/ConfigurableJRuby
    config :- jruby-schemas/JRubyConfig]
-  (let [{:keys [ruby-load-path compile-mode lifecycle]} config
+  (let [{:keys [ruby-load-path compile-mode lifecycle compat-version]} config
         initialize-scripting-container-fn (:initialize-scripting-container lifecycle)]
     (doto jruby
       (.setLoadPaths ruby-load-path)
-      (.setCompatVersion compat-version)
+      (.setCompatVersion (get-compat-version compat-version))
       (.setCompileMode (get-compile-mode compile-mode)))
     (initialize-scripting-container-fn jruby config)))
 

--- a/src/clj/puppetlabs/services/jruby_pool_manager/impl/jruby_internal.clj
+++ b/src/clj/puppetlabs/services/jruby_pool_manager/impl/jruby_internal.clj
@@ -39,7 +39,10 @@
   [compat-version :- jruby-schemas/SupportedJRubyCompatVersions]
   (case compat-version
     "1.9" (CompatVersion/RUBY1_9)
-    "2.0" (CompatVersion/RUBY2_0)))
+    "2.0" (CompatVersion/RUBY2_0)
+    (throw (IllegalArgumentException.
+            (format (str "compat-version is set to `%s`, which is not an allowed option."
+                         " The available compat-versions are `1.9` and `2.0`") compat-version)))))
 
 (schema/defn ^:always-validate init-jruby :- jruby-schemas/ConfigurableJRuby
   "Applies configuration to a JRuby... thing.  See comments in `ConfigurableJRuby`

--- a/src/clj/puppetlabs/services/jruby_pool_manager/jruby_core.clj
+++ b/src/clj/puppetlabs/services/jruby_pool_manager/jruby_core.clj
@@ -142,6 +142,12 @@
       (update-in [:initialize-scripting-container]
                  #(or % default-initialize-scripting-container))))
 
+(defn parse-compat-version
+  [compat-version]
+  (cond-> compat-version
+          (integer? compat-version) double
+          :true str))
+
 (schema/defn ^:always-validate
   initialize-config :- jruby-schemas/JRubyConfig
   "Initialize keys with default settings if they are not given a value.
@@ -149,7 +155,7 @@
   [config :- {schema/Keyword schema/Any}]
   (-> config
       (update-in [:compile-mode] #(keyword (or % default-jruby-compile-mode)))
-      (update-in [:compat-version] #(str (or % default-jruby-compat-version)))
+      (update-in [:compat-version] #(parse-compat-version (or % default-jruby-compat-version)))
       (update-in [:borrow-timeout] #(or % default-borrow-timeout))
       (update-in [:max-active-instances] #(or % (default-pool-size (ks/num-cpus))))
       (update-in [:max-borrows-per-instance] #(or % 0))

--- a/src/clj/puppetlabs/services/jruby_pool_manager/jruby_core.clj
+++ b/src/clj/puppetlabs/services/jruby_pool_manager/jruby_core.clj
@@ -20,6 +20,10 @@
   "Default value for JRuby's 'CompileMode' setting."
   :off)
 
+(def default-jruby-compat-version
+  "Default value for JRuby's 'CompatVersion' setting."
+  "1.9")
+
 (def default-borrow-timeout
   "Default timeout when borrowing instances from the JRuby pool in
    milliseconds. Current value is 1200000ms, or 20 minutes."
@@ -145,6 +149,7 @@
   [config :- {schema/Keyword schema/Any}]
   (-> config
       (update-in [:compile-mode] #(keyword (or % default-jruby-compile-mode)))
+      (update-in [:compat-version] #(str (or % default-jruby-compat-version)))
       (update-in [:borrow-timeout] #(or % default-borrow-timeout))
       (update-in [:max-active-instances] #(or % (default-pool-size (ks/num-cpus))))
       (update-in [:max-borrows-per-instance] #(or % 0))

--- a/src/clj/puppetlabs/services/jruby_pool_manager/jruby_schemas.clj
+++ b/src/clj/puppetlabs/services/jruby_pool_manager/jruby_schemas.clj
@@ -40,6 +40,13 @@
   "Schema defining the supported values for the JRuby CompileMode setting."
   (apply schema/enum supported-jruby-compile-modes))
 
+(def supported-jruby-compat-versions
+  #{"1.9" "2.0"})
+
+(def SupportedJRubyCompatVersions
+  "Schema defining the supported compatability versions for the JRuby CompatVersions setting"
+  (apply schema/enum supported-jruby-compat-versions))
+
 (def LifecycleFns
   {:initialize-pool-instance IFn
    :cleanup IFn
@@ -69,6 +76,7 @@
    :gem-home schema/Str
    :gem-path (schema/maybe schema/Str)
    :compile-mode SupportedJRubyCompileModes
+   :compat-version SupportedJRubyCompatVersions
    :borrow-timeout schema/Int
    :max-active-instances schema/Int
    :max-borrows-per-instance schema/Int

--- a/test/integration/puppetlabs/services/jruby_pool_manager/jruby_internal_test.clj
+++ b/test/integration/puppetlabs/services/jruby_pool_manager/jruby_internal_test.clj
@@ -4,7 +4,7 @@
             [puppetlabs.services.jruby-pool-manager.jruby-testutils :as jruby-testutils]
             [puppetlabs.services.jruby-pool-manager.jruby-schemas :as jruby-schemas])
   (:import (com.puppetlabs.jruby_utils.pool JRubyPool)
-           (org.jruby RubyInstanceConfig$CompileMode)
+           (org.jruby RubyInstanceConfig$CompileMode CompatVersion)
            (clojure.lang ExceptionInfo)))
 
 (deftest get-compile-mode-test
@@ -30,11 +30,28 @@
   (testing "setting plumbed into jruby container for"
     (let [pool (JRubyPool. 1)
           config (jruby-testutils/jruby-config
-                  {:compile-mode :jit})
+                  {:compile-mode :jit
+                   :compat-version 2.0})
           instance (jruby-internal/create-pool-instance! pool 0 config #())
           container (:scripting-container instance)]
       (try
         (is (= RubyInstanceConfig$CompileMode/JIT
             (.getCompileMode container)))
+        (is (.is2_0 (.getCompatVersion container)))
         (finally
           (.terminate container))))))
+
+(deftest get-compat-version-test
+  (testing "returns correct compat version for SupportedJrubyCompatVersions enum"
+    (is (not (.is2_0 (jruby-internal/get-compat-version "1.9"))))
+    (is (.is2_0 (jruby-internal/get-compat-version "2.0"))))
+  (testing "returns a valid CompileMode for all values of enum"
+    (doseq [version jruby-schemas/supported-jruby-compat-versions]
+      (is (instance? CompatVersion
+                     (jruby-internal/get-compat-version version)))))
+  (testing "throws an exception if mode is nil"
+    (is (thrown? ExceptionInfo
+                 (jruby-internal/get-compat-version nil))))
+  (testing "throws an exception for values not in enum"
+    (is (thrown? ExceptionInfo
+                 (jruby-internal/get-compat-version :foo)))))

--- a/test/integration/puppetlabs/services/jruby_pool_manager/jruby_internal_test.clj
+++ b/test/integration/puppetlabs/services/jruby_pool_manager/jruby_internal_test.clj
@@ -43,9 +43,10 @@
 
 (deftest get-compat-version-test
   (testing "returns correct compat version for SupportedJrubyCompatVersions enum"
+    (is (.is1_9 (jruby-internal/get-compat-version "1.9")))
     (is (not (.is2_0 (jruby-internal/get-compat-version "1.9"))))
     (is (.is2_0 (jruby-internal/get-compat-version "2.0"))))
-  (testing "returns a valid CompileMode for all values of enum"
+  (testing "returns a valid CompatVersion for all values of enum"
     (doseq [version jruby-schemas/supported-jruby-compat-versions]
       (is (instance? CompatVersion
                      (jruby-internal/get-compat-version version)))))
@@ -54,4 +55,4 @@
                  (jruby-internal/get-compat-version nil))))
   (testing "throws an exception for values not in enum"
     (is (thrown? ExceptionInfo
-                 (jruby-internal/get-compat-version :foo)))))
+                 (jruby-internal/get-compat-version "foo")))))

--- a/test/unit/puppetlabs/services/jruby_pool_manager/jruby_pool_test.clj
+++ b/test/unit/puppetlabs/services/jruby_pool_manager/jruby_pool_test.clj
@@ -69,6 +69,13 @@
                        (assoc :compat-version 2.0)
                        (jruby-core/initialize-config)
                        :compat-version))))
+    (testing "compat-version is honored if specified as an integer"
+      ;; HOCON might parse doubles as integers in some cases? so we should tolerate it as an integer
+      ;; too
+      (is (= "2.0" (-> minimal-config
+                       (assoc :compat-version 2)
+                       (jruby-core/initialize-config)
+                       :compat-version))))
     (testing "gem-path is set to nil if not specified"
       (is (nil? (-> minimal-config
                     jruby-core/initialize-config

--- a/test/unit/puppetlabs/services/jruby_pool_manager/jruby_pool_test.clj
+++ b/test/unit/puppetlabs/services/jruby_pool_manager/jruby_pool_test.clj
@@ -46,6 +46,29 @@
                       (assoc :compile-mode "jit")
                       (jruby-core/initialize-config)
                       :compile-mode))))
+    (testing "compat-version is set to default if not specified"
+      (is (= jruby-core/default-jruby-compat-version
+             (:compat-version config))))
+    (testing "compat-version is honored if specified as a string"
+      (is (= "1.9" (-> minimal-config
+                       (assoc :compat-version "1.9")
+                       (jruby-core/initialize-config)
+                       :compat-version)))
+      (is (= "2.0" (-> minimal-config
+                       (assoc :compat-version "2.0")
+                       (jruby-core/initialize-config)
+                       :compat-version))))
+    (testing "compat-version is honored if specified as a double"
+      ;; depending on how the setting is laid down in a HOCON file, it seems feasible that it might
+      ;; be a string or a double. We should tolerate either.
+      (is (= "1.9" (-> minimal-config
+                       (assoc :compat-version 1.9)
+                       (jruby-core/initialize-config)
+                       :compat-version)))
+      (is (= "2.0" (-> minimal-config
+                       (assoc :compat-version 2.0)
+                       (jruby-core/initialize-config)
+                       :compat-version))))
     (testing "gem-path is set to nil if not specified"
       (is (nil? (-> minimal-config
                     jruby-core/initialize-config


### PR DESCRIPTION
Add a `compat-version` JRuby setting to allow configuration of the
compatibility version. The valid options are 1.9 or 2.0. This is tolerated as
a string or a double (so we don't need to worry about conversions between
Hiera/NC and HOCON parsing). The default is 1.9.