### PR TITLE
(MAINT) Prep for 0.4.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+### 0.4.0 - 2016-10-19
+
+This is a minor feature release.
+
+Features:
+
+* Introduce support for a `compat-version` config option, which allows the MRI
+  compatibility version to be configured.  Only supports 1.9 or 2.0, with 1.9
+  being the default if not specified.
+
 ### 0.3.0 - 2016-10-05
 
 This is a minor feature release and maintenance release.

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject puppetlabs/jruby-utils "0.3.1-SNAPSHOT"
+(defproject puppetlabs/jruby-utils "0.4.0-SNAPSHOT"
   :description "A library for working with JRuby"
   :url "https://github.com/puppetlabs/jruby-utils"
   :license {:name "Apache License, Version 2.0"


### PR DESCRIPTION
This commit adds a release note and bumps the project.clj version in
support of an 0.4.0 release.