### PR TITLE
(SERVER-377) Allow proxy environment variables to pass through

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,8 @@ This is a maintenance release.
 This is a feature release.
 
  * [SERVER-584](https://tickets.puppetlabs.com/browse/SERVER-584)
-   Introduce a whitelisting capability to improve the handling of environment variables.
+   Introduce a setting to allow configured environment variables to be passed
+   through to the JRuby scripting container.
 
 ### 0.1.0
 

--- a/src/clj/puppetlabs/services/jruby_pool_manager/jruby_core.clj
+++ b/src/clj/puppetlabs/services/jruby_pool_manager/jruby_core.clj
@@ -90,6 +90,10 @@
     (assoc env "GEM_PATH" gem-path)
     env))
 
+(def env-allowed-list
+  "A list of environment variables that are allowed to be passed through from the environment."
+  ["HOME" "PATH" "HTTP_PROXY" "http_proxy" "HTTPS_PROXY" "https_proxy" "NO_PROXY" "no_proxy" "bar"])
+
 (schema/defn ^:always-validate managed-environment :- jruby-schemas/EnvMap
   "The environment variables that should be passed to the JRuby interpreters.
 
@@ -107,13 +111,12 @@
   JARS_NO_REQUIRE is honored.  Setting both of those here for forward
   compatibility.
 
-  We also merge an environment-vars map with the config to allow for whitelisted
+  We also merge an environment-vars map with the config to allow for configured
   environment variables to be visible to the Ruby code. This map is by default
   set to {} if the user does not specify it in the configuration file."
   [env :- jruby-schemas/EnvMap
    config :- jruby-schemas/JRubyConfig]
-  (let [whitelist ["HOME" "PATH"]
-        clean-env (select-keys env whitelist)]
+  (let [clean-env (select-keys env env-allowed-list)]
     (merge (-> (assoc clean-env
                  "GEM_HOME" (:gem-home config)
                  "JARS_NO_REQUIRE" "true"

--- a/src/clj/puppetlabs/services/jruby_pool_manager/jruby_core.clj
+++ b/src/clj/puppetlabs/services/jruby_pool_manager/jruby_core.clj
@@ -90,9 +90,13 @@
     (assoc env "GEM_PATH" gem-path)
     env))
 
-(def env-allowed-list
+(def proxy-vars-allowed-list
+  "A list of proxy-related variables that are allowed to be passed the environment"
+  ["HTTP_PROXY" "http_proxy" "HTTPS_PROXY" "https_proxy" "NO_PROXY" "no_proxy"])
+
+(def env-vars-allowed-list
   "A list of environment variables that are allowed to be passed through from the environment."
-  ["HOME" "PATH" "HTTP_PROXY" "http_proxy" "HTTPS_PROXY" "https_proxy" "NO_PROXY" "no_proxy" "bar"])
+  (concat proxy-vars-allowed-list ["HOME" "PATH"]))
 
 (schema/defn ^:always-validate managed-environment :- jruby-schemas/EnvMap
   "The environment variables that should be passed to the JRuby interpreters.
@@ -116,7 +120,7 @@
   set to {} if the user does not specify it in the configuration file."
   [env :- jruby-schemas/EnvMap
    config :- jruby-schemas/JRubyConfig]
-  (let [clean-env (select-keys env env-allowed-list)]
+  (let [clean-env (select-keys env env-vars-allowed-list)]
     (merge (-> (assoc clean-env
                  "GEM_HOME" (:gem-home config)
                  "JARS_NO_REQUIRE" "true"

--- a/src/clj/puppetlabs/services/jruby_pool_manager/jruby_schemas.clj
+++ b/src/clj/puppetlabs/services/jruby_pool_manager/jruby_schemas.clj
@@ -70,8 +70,8 @@
     * :max-active-instances - The maximum number of JRubyInstances that
         will be pooled.
 
-    * :environment-vars - A map of whitelisted environment variables and their values to be
-        whitelisted and visible to any Ruby code."
+    * :environment-vars - A map of environment variables and their values to be
+        passed through to the JRuby scripting container and visible to any Ruby code."
   {:ruby-load-path [schema/Str]
    :gem-home schema/Str
    :gem-path (schema/maybe schema/Str)

--- a/test/unit/puppetlabs/services/jruby_pool_manager/jruby_interpreter_test.clj
+++ b/test/unit/puppetlabs/services/jruby_pool_manager/jruby_interpreter_test.clj
@@ -1,7 +1,8 @@
 (ns puppetlabs.services.jruby-pool-manager.jruby-interpreter-test
   (:require [clojure.test :refer :all]
             [puppetlabs.services.jruby-pool-manager.jruby-testutils :as jruby-testutils]
-            [puppetlabs.services.jruby-pool-manager.impl.jruby-internal :as jruby-internal]))
+            [puppetlabs.services.jruby-pool-manager.impl.jruby-internal :as jruby-internal]
+            [puppetlabs.services.jruby-pool-manager.jruby-core :as jruby-core]))
 
 (deftest jruby-env-vars
   (testing "the environment used by the JRuby interpreters"
@@ -9,25 +10,23 @@
                               (jruby-testutils/jruby-config))
           jruby-env (.runScriptlet jruby-interpreter "ENV")]
       ;; $HOME and $PATH are left in by `jruby-env`
-      ;; Note that other environment variables are allowed through (e.g. `HTTP_PROXY` -
-      ;; see jruby-core/env-allowed-list for the full list), but are not
-      ;; expected to show up in most environments.
-      ;; If this test starts failing because CI systems or local development
-      ;; environments do have these variables set, we may need to revisit
-      ;; this test.
+      ;; Note that other environment variables are allowed through (e.g.
+      ;; `HTTP_PROXY` - see jruby-core/env-vars-allowed-list for the full list),
+      ;; but are not expected to be set in most environments. However, in
+      ;; order to make this more test robust, these variables are always
+      ;; filtered out.
       (is (= #{"HOME" "PATH" "GEM_HOME" "JARS_NO_REQUIRE" "JARS_REQUIRE" "RUBY"}
-             (set (keys jruby-env)))))))
+             (set (remove (set jruby-core/proxy-vars-allowed-list) (keys jruby-env))))))))
 
 (deftest jruby-configured-env-vars
   (testing "the environment used by the JRuby interpreters can be added to via the config"
     (let [jruby-interpreter (jruby-internal/create-scripting-container
                              (jruby-testutils/jruby-config {:environment-vars {:FOO "for_jruby"}}))
           jruby-env (.runScriptlet jruby-interpreter "ENV")]
-      ;; Note that other environment variables are allowed through but are not
-      ;; expected to show up in most environments.
-      ;; If this test starts failing because CI systems or local development
-      ;; environments do have these variables set, we may need to revisit
-      ;; this test.
+      ;; Note that other environment variables are allowed through,
+      ;; but are not expected to be set in most environments. However, in
+      ;; order to make this test more robust, these variables are always
+      ;; filtered out.
       (is (= #{"HOME" "PATH" "GEM_HOME" "JARS_NO_REQUIRE" "JARS_REQUIRE" "FOO" "RUBY"}
-             (set (keys jruby-env))))
+             (set (remove (set jruby-core/proxy-vars-allowed-list) (keys jruby-env)))))
       (is (= (.get jruby-env "FOO") "for_jruby")))))

--- a/test/unit/puppetlabs/services/jruby_pool_manager/jruby_interpreter_test.clj
+++ b/test/unit/puppetlabs/services/jruby_pool_manager/jruby_interpreter_test.clj
@@ -8,15 +8,26 @@
     (let [jruby-interpreter (jruby-internal/create-scripting-container
                               (jruby-testutils/jruby-config))
           jruby-env (.runScriptlet jruby-interpreter "ENV")]
-      ; $HOME and $PATH are left in by `jruby-env`
+      ;; $HOME and $PATH are left in by `jruby-env`
+      ;; Note that other environment variables are allowed through (e.g. `HTTP_PROXY` -
+      ;; see jruby-core/env-allowed-list for the full list), but are not
+      ;; expected to show up in most environments.
+      ;; If this test starts failing because CI systems or local development
+      ;; environments do have these variables set, we may need to revisit
+      ;; this test.
       (is (= #{"HOME" "PATH" "GEM_HOME" "JARS_NO_REQUIRE" "JARS_REQUIRE" "RUBY"}
              (set (keys jruby-env)))))))
 
-(deftest jruby-whitelist-env-vars
-  (testing "the environment used by the JRuby interpreters"
+(deftest jruby-configured-env-vars
+  (testing "the environment used by the JRuby interpreters can be added to via the config"
     (let [jruby-interpreter (jruby-internal/create-scripting-container
                              (jruby-testutils/jruby-config {:environment-vars {:FOO "for_jruby"}}))
           jruby-env (.runScriptlet jruby-interpreter "ENV")]
+      ;; Note that other environment variables are allowed through but are not
+      ;; expected to show up in most environments.
+      ;; If this test starts failing because CI systems or local development
+      ;; environments do have these variables set, we may need to revisit
+      ;; this test.
       (is (= #{"HOME" "PATH" "GEM_HOME" "JARS_NO_REQUIRE" "JARS_REQUIRE" "FOO" "RUBY"}
              (set (keys jruby-env))))
       (is (= (.get jruby-env "FOO") "for_jruby")))))


### PR DESCRIPTION
jruby-utils limits the environment variables that it passes through to the
jruby interpreters. Previously, the list of environment variables allowed to
pass through did not include any proxy-related variables. This was a problem
because in some environments these variables are necessary for installing
gems, and rubygems respects these variables.

This commit adds the environment variables `HTTP_PROXY`, `http_proxy`,
`HTTPS_PROXY`, `https_proxy`, `NO_PROXY`, and `no_proxy` to be passed through
to the jruby scripting container.

In most cases developer workstations and CI systems won't have these variables
set, and there is no good way (without adding additional libraries and doing
some amount of hackery) to mock them out for tests. Thus, no tests have been
added or modified to test this change. However, there will be acceptance tests (using
beaker) added in puppetserver to test that these environment variables are now
being set.