### PR TITLE
(SERVER-1475) Add an JRuby slf4j Logger adapter

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -50,7 +50,8 @@
   :classifiers [["test" :testutils]]
 
   :profiles {:dev {:dependencies  [[puppetlabs/kitchensink :classifier "test" :scope "test"]
-                                   [puppetlabs/trapperkeeper :classifier "test" :scope "test"]]}
+                                   [puppetlabs/trapperkeeper :classifier "test" :scope "test"]]
+                   :jvm-opts ["-Djruby.logger.class=com.puppetlabs.jruby_utils.jruby.Slf4jLogger"]}
              :testutils {:source-paths ^:replace ["test/unit" "test/integration"]}}
 
   :plugins [[lein-parent "0.3.1"]]

--- a/src/java/com/puppetlabs/jruby_utils/jruby/Slf4jLogger.java
+++ b/src/java/com/puppetlabs/jruby_utils/jruby/Slf4jLogger.java
@@ -1,0 +1,88 @@
+package com.puppetlabs.jruby_utils.jruby;
+
+import org.jruby.util.log.Logger;
+import org.slf4j.LoggerFactory;
+
+public class Slf4jLogger implements Logger {
+
+    private final org.slf4j.Logger logger;
+
+    public Slf4jLogger(String loggerName) {
+        logger = LoggerFactory.getLogger("jruby." + loggerName);
+    }
+
+    @Override
+    public String getName() {
+        return logger.getName();
+    }
+
+    @Override
+    public void warn(String message, Object... args) {
+        logger.warn(message, args);
+    }
+
+    @Override
+    public void warn(Throwable throwable) {
+        logger.warn("", throwable);
+    }
+
+    @Override
+    public void warn(String message, Throwable throwable) {
+        logger.warn(message, throwable);
+    }
+
+    @Override
+    public void error(String message, Object... args) {
+        logger.error(message, args);
+    }
+
+    @Override
+    public void error(Throwable throwable) {
+        logger.error("", throwable);
+    }
+
+    @Override
+    public void error(String message, Throwable throwable) {
+        logger.error(message, throwable);
+    }
+
+    @Override
+    public void info(String message, Object... args) {
+        logger.info(message, args);
+    }
+
+    @Override
+    public void info(Throwable throwable) {
+        logger.info("", throwable);
+    }
+
+    @Override
+    public void info(String message, Throwable throwable) {
+        logger.info(message, throwable);
+    }
+
+    @Override
+    public void debug(String message, Object... args) {
+        logger.debug(message, args);
+    }
+
+    @Override
+    public void debug(Throwable throwable) {
+        logger.debug("", throwable);
+    }
+
+    @Override
+    public void debug(String message, Throwable throwable) {
+        logger.debug(message, throwable);
+    }
+
+    @Override
+    public boolean isDebugEnabled() {
+        return true;
+    }
+
+    @Override
+    public void setDebugEnable(boolean b) {
+        warn("setDebugEnable not implemented", null, null);
+    }
+}

--- a/test/unit/puppetlabs/jruby_utils/slj4j_logger_test.clj
+++ b/test/unit/puppetlabs/jruby_utils/slj4j_logger_test.clj
@@ -1,13 +1,13 @@
 (ns puppetlabs.jruby-utils.slj4j-logger-test
   (:require [clojure.test :refer :all]
             [puppetlabs.trapperkeeper.testutils.logging :as logutils])
-  (:import (com.puppetlabs.jruby_utils.jruby Slf4jLogger)))
+  (:import (org.jruby.util.log LoggerFactory)))
 
 (deftest slf4j-logger-test
   (let [actual-logger-name "my-test-logger"
         exception-message "exceptionally bad news"
         expected-logger-name (str "jruby." actual-logger-name)
-        logger (Slf4jLogger. actual-logger-name)
+        logger (LoggerFactory/getLogger actual-logger-name)
         actual-log-event (fn [event]
                            (assoc event :exception
                                         (when-let [exception (:exception event)]

--- a/test/unit/puppetlabs/jruby_utils/slj4j_logger_test.clj
+++ b/test/unit/puppetlabs/jruby_utils/slj4j_logger_test.clj
@@ -1,0 +1,93 @@
+(ns puppetlabs.jruby-utils.slj4j-logger-test
+  (:require [clojure.test :refer :all]
+            [puppetlabs.trapperkeeper.testutils.logging :as logutils])
+  (:import (com.puppetlabs.jruby_utils.jruby Slf4jLogger)))
+
+(deftest slf4j-logger-test
+  (let [actual-logger-name "my-test-logger"
+        exception-message "exceptionally bad news"
+        expected-logger-name (str "jruby." actual-logger-name)
+        logger (Slf4jLogger. actual-logger-name)
+        actual-log-event (fn [event]
+                           (assoc event :exception
+                                        (when-let [exception (:exception event)]
+                                          (.getMessage exception))))
+        expected-log-event (fn [message level exception]
+                             {:message message
+                              :level level
+                              :exception exception
+                              :logger expected-logger-name})]
+    (testing "name stored in logger"
+      (is (= expected-logger-name (.getName logger))))
+
+    (testing "warn with a string and objects"
+      (logutils/with-test-logging
+       (.warn logger "a {} {} warning" (into-array Object ["strongly" "worded"]))
+       (is (logged? "a {} {} warning" :warn))))
+    (testing "warn with an exception"
+      (logutils/with-test-logging
+       (.warn logger (Exception. exception-message))
+       (is (logged?
+            #(= (expected-log-event "" :warn exception-message)
+                (actual-log-event %))))))
+    (testing "warn with a string and an exception"
+      (logutils/with-test-logging
+       (.warn logger "a warning" (Exception. exception-message))
+       (is (logged?
+            #(= (expected-log-event "a warning" :warn exception-message)
+                (actual-log-event %))))))
+
+    (testing "error with a string and objects"
+      (logutils/with-test-logging
+       (.error logger "a {} {} error" (into-array Object ["strongly" "worded"]))
+       (is (logged? "a {} {} error" :error))))
+    (testing "error with an exception"
+      (logutils/with-test-logging
+       (.error logger (Exception. exception-message))
+       (is (logged?
+            #(= (expected-log-event "" :error exception-message)
+                (actual-log-event %))))))
+    (testing "error with a string and an exception"
+      (logutils/with-test-logging
+       (.error logger "an error" (Exception. exception-message))
+       (is (logged?
+            #(= (expected-log-event "an error" :error exception-message)
+                (actual-log-event %))))))
+
+    (testing "info with a string and objects"
+      (logutils/with-test-logging
+       (.info logger
+              "some {} {} info"
+              (into-array Object ["strongly" "worded"]))
+       (is (logged? "some {} {} info" :info))))
+    (testing "info with an exception"
+      (logutils/with-test-logging
+       (.info logger (Exception. exception-message))
+       (is (logged?
+            #(= (expected-log-event "" :info exception-message)
+                (actual-log-event %))))))
+    (testing "info with a string and an exception"
+      (logutils/with-test-logging
+       (.info logger "some info" (Exception. exception-message))
+       (is (logged?
+            #(= (expected-log-event "some info" :info exception-message)
+                (actual-log-event %))))))
+
+    (testing "debug with a string and objects"
+      (logutils/with-test-logging
+       (.debug logger
+               "some {} {} debug"
+               (into-array Object ["strongly" "worded"]))
+       (is (logged? "some {} {} debug" :debug))))
+    (testing "info with an exception"
+      (logutils/with-test-logging
+       (.debug logger (Exception. exception-message))
+       (is (logged?
+            #(= (expected-log-event "" :debug exception-message)
+                (actual-log-event %))))))
+    (testing "debug with a string and an exception"
+      (logutils/with-test-logging
+       (.debug logger "some debug" (Exception. exception-message))
+       (is (logged?
+            #(= (expected-log-event "some debug" :debug exception-message)
+                (actual-log-event %))))))))


### PR DESCRIPTION
This commit adds a class, Slf4jLogger, which implements the JRuby Logger
interface, forwarding any logging calls which are received on to an
slf4j logger.  This class doesn't actually hook up the logger to created
JRuby instances since JRuby classes typically get the object that they
use for logging during static initialization, which would most likely
complete before any attempt to set a custom logger with JRuby could be
done.  Use of this Logger would typically require that the consuming
process set the jruby.logger.class Java system property to the namespace
of the new class on the command line, e.g.,
-Djruby.logger.class=com.puppetlabs.jruby_utils.jruby.Slf4jLogger.