### PR TITLE
(MAINT) Prep for 0.6.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+### 0.6.0 - 2016-12-19
+
+This is a feature release.
+
+* [SERVER-1475](https://tickets.puppetlabs.com/browse/SERVER-1475) Introduce
+  an Slf4jLogger class for use in routing JRuby log output to slf4j.
+
 ### 0.5.0 - 2016-11-22
 
 This is a minor feature release.

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject puppetlabs/jruby-utils "0.5.1-SNAPSHOT"
+(defproject puppetlabs/jruby-utils "0.6.0-SNAPSHOT"
   :description "A library for working with JRuby"
   :url "https://github.com/puppetlabs/jruby-utils"
   :license {:name "Apache License, Version 2.0"


### PR DESCRIPTION
This commit bumps the project.clj version to 0.6.0-SNAPSHOT and adds
notes to the CHANGELOG.md for the upcoming 0.6.0 release.