### PR TITLE
(MAINT) Bump version for 0.7.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+### 0.7.0 - 2017-01-03
+
+This is a bugfix and internal improvement release.
+
+* Remove the need for a second `JrubyPool` during pool flushes to improve
+  system stability
+* Fix possibility of race condition where the pool lock can be granted even
+  when some jruby instances are still doing work
+
 ### 0.6.0 - 2016-12-19
 
 This is a feature release.

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject puppetlabs/jruby-utils "0.6.1-SNAPSHOT"
+(defproject puppetlabs/jruby-utils "0.7.0-SNAPSHOT"
   :description "A library for working with JRuby"
   :url "https://github.com/puppetlabs/jruby-utils"
   :license {:name "Apache License, Version 2.0"


### PR DESCRIPTION
### 0.7.0 - 2017-01-03

This is a bugfix and internal improvement release.

* Remove the need for a second `JrubyPool` during pool flushes to improve
  system stability
* Fix possibility of race condition where the pool lock can be granted even
  when some jruby instances are still doing work