### PR TITLE
Server 1704 introduce pool lock timeout

### DIFF
--- a/src/clj/puppetlabs/services/jruby_pool_manager/impl/jruby_agents.clj
+++ b/src/clj/puppetlabs/services/jruby_pool_manager/impl/jruby_agents.clj
@@ -89,7 +89,7 @@
                                           (partial send-flush-instance! pool-context))))
 
 (schema/defn borrow-all-jrubies*
-  "The core logic for borrow-all-jrubies. Should not be called from borrow-all-jrubies"
+  "The core logic for borrow-all-jrubies. Should only be called from borrow-all-jrubies"
   [pool-context :- jruby-schemas/PoolContext
    borrow-exception :- IDeref]
   (let [pool-size (jruby-internal/get-pool-size pool-context)

--- a/src/clj/puppetlabs/services/jruby_pool_manager/impl/jruby_agents.clj
+++ b/src/clj/puppetlabs/services/jruby_pool_manager/impl/jruby_agents.clj
@@ -124,7 +124,8 @@
       (.lockWithTimeout pool flush-timeout TimeUnit/MILLISECONDS)
       (catch TimeoutException e
         (sling/throw+ {:kind ::jruby-lock-timeout
-                       :msg (.getMessage e)})))
+                       :msg (i18n/trs "An attempt to lock the JRubyPool failed with a timeout")}
+                      e)))
 
     ; Bit of a hack to work around shutdown-on-error behavior:
     ; shutdown-on-error will either return the jrubies as expected,

--- a/src/clj/puppetlabs/services/jruby_pool_manager/impl/jruby_internal.clj
+++ b/src/clj/puppetlabs/services/jruby_pool_manager/impl/jruby_internal.clj
@@ -171,6 +171,12 @@
   (get-in context [:config :max-active-instances]))
 
 (schema/defn ^:always-validate
+  get-flush-timeout :- schema/Int
+  "Gets the size of the JRuby pool from the pool context."
+  [context :- jruby-schemas/PoolContext]
+  (get-in context [:config :flush-timeout]))
+
+(schema/defn ^:always-validate
   get-instance-state-container :- jruby-schemas/JRubyInstanceStateContainer
   "Gets the InstanceStateContainer (atom) from the instance."
   [instance :- JRubyInstance]

--- a/src/clj/puppetlabs/services/jruby_pool_manager/jruby_core.clj
+++ b/src/clj/puppetlabs/services/jruby_pool_manager/jruby_core.clj
@@ -30,6 +30,11 @@
    milliseconds. Current value is 1200000ms, or 20 minutes."
   1200000)
 
+(def default-flush-timeout
+  "Default timeout when flushing the JRuby pool in milliseconds.
+  Current value is 1200000ms, or 20 minutes."
+  1200000)
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Functions
 
@@ -165,6 +170,7 @@
       (update-in [:compile-mode] #(keyword (or % default-jruby-compile-mode)))
       (update-in [:compat-version] #(parse-compat-version (or % default-jruby-compat-version)))
       (update-in [:borrow-timeout] #(or % default-borrow-timeout))
+      (update-in [:flush-timeout] #(or % default-flush-timeout))
       (update-in [:max-active-instances] #(or % (default-pool-size (ks/num-cpus))))
       (update-in [:max-borrows-per-instance] #(or % 0))
       (update-in [:environment-vars] #(or % {}))

--- a/src/clj/puppetlabs/services/jruby_pool_manager/jruby_schemas.clj
+++ b/src/clj/puppetlabs/services/jruby_pool_manager/jruby_schemas.clj
@@ -71,6 +71,7 @@
    :compile-mode SupportedJRubyCompileModes
    :compat-version SupportedJRubyCompatVersions
    :borrow-timeout schema/Int
+   :flush-timeout schema/Int
    :max-active-instances schema/Int
    :max-borrows-per-instance schema/Int
    :lifecycle LifecycleFns

--- a/src/java/com/puppetlabs/jruby_utils/pool/JRubyPool.java
+++ b/src/java/com/puppetlabs/jruby_utils/pool/JRubyPool.java
@@ -140,7 +140,7 @@ public final class JRubyPool<E> implements LockablePool<E> {
         try {
             final Thread currentThread = Thread.currentThread();
             do {
-                if (this.pill != null){
+                if (this.pill != null) {
                     // Return the pill immediately if there is one
                     item = pill;
                 } else if (isPoolLockHeldByAnotherThread(currentThread)) {
@@ -178,7 +178,7 @@ public final class JRubyPool<E> implements LockablePool<E> {
             // `LinkedBlockingDeque` in `pollFirst` uses.  See:
             // http://hg.openjdk.java.net/jdk8/jdk8/jdk/file/687fd7c7986d/src/share/classes/java/util/concurrent/LinkedBlockingDeque.java#l522
             do {
-                if (this.pill != null){
+                if (this.pill != null) {
                     // Return the pill immediately if there is one
                     item = pill;
                 } else if (isPoolLockHeldByAnotherThread(currentThread)) {
@@ -216,8 +216,8 @@ public final class JRubyPool<E> implements LockablePool<E> {
         final ReentrantLock lock = this.queueLock;
         lock.lock();
         try {
-            if (e != this.pill){
-                if (!isRegistered(e)){
+            if (e != this.pill) {
+                if (!isRegistered(e)) {
                     String errorMsg = "The item being released is not registered with the pool";
                     throw new IllegalArgumentException(errorMsg);
                 }
@@ -229,7 +229,7 @@ public final class JRubyPool<E> implements LockablePool<E> {
         }
     }
 
-    private boolean isRegistered(E e){
+    private boolean isRegistered(E e) {
         return this.registeredElements.contains(e);
     }
 
@@ -243,7 +243,7 @@ public final class JRubyPool<E> implements LockablePool<E> {
         final ReentrantLock lock = this.queueLock;
         lock.lock();
         try {
-            if (this.pill == null){
+            if (this.pill == null) {
                 this.pill = e;
                 signalPoolNotEmpty();
             }
@@ -322,7 +322,7 @@ public final class JRubyPool<E> implements LockablePool<E> {
 
             final Thread currentThread = Thread.currentThread();
             while (!isPoolLockHeldByCurrentThread(currentThread)) {
-                if (this.pill != null){
+                if (this.pill != null) {
                     throw new InterruptedException(pillErrorMsg);
                 }
                 if (!isPoolLockHeld()) {
@@ -335,7 +335,7 @@ public final class JRubyPool<E> implements LockablePool<E> {
                 // Wait until the pool has been completely filled
                 while (liveQueue.size() != this.maxSize) {
                     lockAvailable.await();
-                    if (this.pill != null){
+                    if (this.pill != null) {
                         throw new InterruptedException(pillErrorMsg);
                     }
                 }
@@ -364,7 +364,7 @@ public final class JRubyPool<E> implements LockablePool<E> {
 
             final Thread currentThread = Thread.currentThread();
             while (!isPoolLockHeldByCurrentThread(currentThread)) {
-                if (this.pill != null){
+                if (this.pill != null) {
                     throw new InterruptedException(pillErrorMsg);
                 }
 
@@ -386,7 +386,7 @@ public final class JRubyPool<E> implements LockablePool<E> {
                     }
                     remainingMaxTimeToWait = lockAvailable.awaitNanos(remainingMaxTimeToWait);
 
-                    if (this.pill != null){
+                    if (this.pill != null) {
                         throw new InterruptedException(pillErrorMsg);
                     }
                 }

--- a/src/java/com/puppetlabs/jruby_utils/pool/JRubyPool.java
+++ b/src/java/com/puppetlabs/jruby_utils/pool/JRubyPool.java
@@ -490,8 +490,8 @@ public final class JRubyPool<E> implements LockablePool<E> {
         // Could use 'signalAll' here instead of 'signal'.  Doesn't really
         // matter though in that there will only be one waiter at most which
         // is active at a time - a caller of lock() that has just acquired
-        // the pool lock but is waiting for all registered elements to be
-        // returned to the queue.
+        // the pool lock but is waiting for the live queue to be completely
+        // filled
         if (this.maxSize == liveQueue.size() || pill != null) {
             lockAvailable.signal();
         }

--- a/src/java/com/puppetlabs/jruby_utils/pool/JRubyPool.java
+++ b/src/java/com/puppetlabs/jruby_utils/pool/JRubyPool.java
@@ -491,8 +491,7 @@ public final class JRubyPool<E> implements LockablePool<E> {
         // is active at a time - a caller of lock() that has just acquired
         // the pool lock but is waiting for all registered elements to be
         // returned to the queue.
-        if (registeredElements.size() == liveQueue.size() ||
-                pill != null) {
+        if (this.maxSize == liveQueue.size() || pill != null) {
             lockAvailable.signal();
         }
     }

--- a/src/java/com/puppetlabs/jruby_utils/pool/JRubyPool.java
+++ b/src/java/com/puppetlabs/jruby_utils/pool/JRubyPool.java
@@ -319,12 +319,12 @@ public final class JRubyPool<E> implements LockablePool<E> {
         lock.lock();
         try {
             String pillErrorMsg = "Lock can't be granted because a pill has been inserted";
-            if (this.pill != null){
-                throw new InterruptedException(pillErrorMsg);
-            }
 
             final Thread currentThread = Thread.currentThread();
             while (!isPoolLockHeldByCurrentThread(currentThread)) {
+                if (this.pill != null){
+                    throw new InterruptedException(pillErrorMsg);
+                }
                 if (!isPoolLockHeld()) {
                     poolLockThread = currentThread;
                 } else {
@@ -361,12 +361,13 @@ public final class JRubyPool<E> implements LockablePool<E> {
         try {
             String pillErrorMsg = "Lock can't be granted because a pill has been inserted";
             String timeoutErrorMsg = "Timeout limit reached before lock could be granted";
-            if (this.pill != null){
-                throw new InterruptedException(pillErrorMsg);
-            }
 
             final Thread currentThread = Thread.currentThread();
             while (!isPoolLockHeldByCurrentThread(currentThread)) {
+                if (this.pill != null){
+                    throw new InterruptedException(pillErrorMsg);
+                }
+
                 if (!isPoolLockHeld()) {
                     poolLockThread = currentThread;
                 } else {

--- a/src/java/com/puppetlabs/jruby_utils/pool/LockablePool.java
+++ b/src/java/com/puppetlabs/jruby_utils/pool/LockablePool.java
@@ -2,6 +2,7 @@ package com.puppetlabs.jruby_utils.pool;
 
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 public interface LockablePool<E> {
 
@@ -138,6 +139,17 @@ public interface LockablePool<E> {
     *                              waiting for the pool to be unlocked
     */
     void lock() throws InterruptedException;
+
+    /**
+     * Lock the pool. Behaves the same as {@link #lock()} but only waits for
+     * the amount of time specified in the <tt>timeout</tt> parameter. Throws
+     * a TimeoutException if the timeout is exceeded.
+     *
+     * @param timeout how long to wait before giving up, in units of unit
+     * @param unit    a <tt>TimeUnit</tt> determining how to interpret the
+     *                <tt>timeout</tt> parameter
+     */
+    void lockWithTimeout(long timeout, TimeUnit unit) throws InterruptedException, TimeoutException;
 
     /**
      * Returns whether or not the pool is currently locked.  Note that the

--- a/test/unit/puppetlabs/jruby_utils/lockable_pool_test.clj
+++ b/test/unit/puppetlabs/jruby_utils/lockable_pool_test.clj
@@ -341,7 +341,8 @@
       (is (thrown-with-msg?
            TimeoutException
            #"Timeout limit reached before lock could be granted"
-           (.lockWithTimeout pool 1 TimeUnit/NANOSECONDS))))))
+           (.lockWithTimeout pool 1 TimeUnit/NANOSECONDS)
+           (is (not (.isLocked pool))))))))
 
 (deftest pool-release-item-test
   (testing "releaseItem returns item to pool and allows pool to still be lockable"


### PR DESCRIPTION
This PR modifies the pool flush code to use a lock timeout.

It also adds a new config setting to specify the timeout.

---

This PR goes along with https://github.com/puppetlabs/puppetserver/pull/1330