### PR TITLE
(SERVER-1704) Add with-lock-with-timeout macro

### DIFF
--- a/test/integration/puppetlabs/services/jruby_pool_manager/jruby_locking_test.clj
+++ b/test/integration/puppetlabs/services/jruby_pool_manager/jruby_locking_test.clj
@@ -5,7 +5,8 @@
             [schema.test :as schema-test]
             [puppetlabs.services.jruby-pool-manager.jruby-core :as jruby-core]
             [puppetlabs.trapperkeeper.testutils.bootstrap :as tk-bootstrap]
-            [puppetlabs.services.protocols.pool-manager :as pool-manager-protocol]))
+            [puppetlabs.services.protocols.pool-manager :as pool-manager-protocol])
+  (:import (java.util.concurrent TimeoutException)))
 
 (use-fixtures :once schema-test/validate-schemas)
 
@@ -127,3 +128,49 @@
          @lock-thread
          (testing "can borrow from non-locking thread after lock released"
            (is (can-borrow-from-different-thread? pool-context))))))))
+
+(deftest ^:integration with-lock-with-timeout-test
+  (testing "can obtain lock when timeout is not exceeded"
+    (tk-bootstrap/with-app-with-config
+     app
+     jruby-testutils/default-services
+     {}
+     (let [config (jruby-test-config 1)
+           pool-manager-service (tk-app/get-service app :PoolManagerService)
+           pool-context (pool-manager-protocol/create-pool pool-manager-service config)
+           pool (jruby-core/get-pool pool-context)]
+
+       (jruby-core/with-lock-with-timeout
+        pool-context
+        10000000
+        :with-lock-holds-lock-test
+        (is (.isLocked pool)))
+       (is (not (.isLocked pool))))))
+
+  (testing "TimeoutException thrown when lock timeout is exceeded"
+    (tk-bootstrap/with-app-with-config
+     app
+     jruby-testutils/default-services
+     {}
+     (let [config (jruby-test-config 1)
+           pool-manager-service (tk-app/get-service app :PoolManagerService)
+           pool-context (pool-manager-protocol/create-pool pool-manager-service config)
+           pool (jruby-core/get-pool pool-context)
+           borrowed-instance (jruby-core/borrow-from-pool
+                              pool-context
+                              :with-lock-with-timeout-test
+                              [])]
+
+       ; Since an instance has been borrowed the lock won't be granted and should
+       ; trigger the timeout immediately
+       (is (thrown-with-msg?
+            TimeoutException
+            #"Timeout limit reached before lock could be granted"
+            (jruby-core/with-lock-with-timeout
+             pool-context
+             1
+             :with-lock-holds-lock-test
+             ; should not reach here
+             (is false))))
+       (is (not (.isLocked pool)))
+       ()))))

--- a/test/integration/puppetlabs/services/jruby_pool_manager/jruby_locking_test.clj
+++ b/test/integration/puppetlabs/services/jruby_pool_manager/jruby_locking_test.clj
@@ -143,7 +143,7 @@
        (jruby-core/with-lock-with-timeout
         pool-context
         10000000
-        :with-lock-holds-lock-test
+        :lock-with-timeout-test
         (is (.isLocked pool)))
        (is (not (.isLocked pool))))))
 
@@ -158,7 +158,7 @@
            pool (jruby-core/get-pool pool-context)
            borrowed-instance (jruby-core/borrow-from-pool
                               pool-context
-                              :with-lock-with-timeout-test
+                              :lock-timeout-exceeded-test
                               [])]
 
        ; Since an instance has been borrowed the lock won't be granted and should
@@ -169,8 +169,7 @@
             (jruby-core/with-lock-with-timeout
              pool-context
              1
-             :with-lock-holds-lock-test
+             :lock-timeout-exceeded-test
              ; should not reach here
              (is false))))
-       (is (not (.isLocked pool)))
-       ()))))
+       (is (not (.isLocked pool)))))))


### PR DESCRIPTION
This commit adds a macro, `with-lock-with-timout`, which is identical to
`with-lock`, except that it accepts a timeout parameter specified in milliseconds

If the timeout is exceeded, a `TimeoutException` will be thrown and the pool
will remain unlocked