### PR TITLE
(MAINT) Update changelog and version for 0.8.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+### 0.8.0 - 2017-03-01
+
+This is a minor feature and bugfix release.
+
+* Introduce `:flush-timeout` config setting to specify how long a pool flush
+  attempt will wait for jruby instances to be returned to the pool before
+  aborting the attempt
+
+* Add `lockWithTimeout` method to the `JrubyPool` class to facilitate the new
+  `:flush-timeout` setting
+
 ### 0.7.0 - 2017-01-03
 
 This is a bugfix and internal improvement release.

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject puppetlabs/jruby-utils "0.7.1-SNAPSHOT"
+(defproject puppetlabs/jruby-utils "0.8.0"
   :description "A library for working with JRuby"
   :url "https://github.com/puppetlabs/jruby-utils"
   :license {:name "Apache License, Version 2.0"


### PR DESCRIPTION
This is a minor feature and bugfix release.

* Introduce `:flush-timeout` config setting to specify how long a pool flush
  attempt will wait for jruby instances to be returned to the pool before
  aborting the attempt

* Add `lockWithTimeout` method to the `JrubyPool` class to facilitate the new
  `:flush-timeout` setting