### PR TITLE
(SERVER-1630) Add support for exercising JRuby 9k

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Clojure.
 
 [![Build Status](https://travis-ci.org/puppetlabs/jruby-utils.svg)](https://travis-ci.org/puppetlabs/jruby-utils)
 
-# Usage
+## Usage
 
 This is a brief overview of the functionality of this library; TODO add more docs.
 
@@ -36,6 +36,21 @@ that no borrows can take place) while you execute some logic.
 In most TK apps where you want to work with JRuby instances, you will want to
 call `create-pool` in the `init` lifecycle of your service, and then call
 `jruby-core/flush-pool-for-shutdown!` in the `stop` lifecycle function.
+
+## Running tests
+
+Clojure unit tests can be run with either a 1.7-based JRuby or 9k-based
+JRuby version.  To run tests with a 1.7-based JRuby, just run:
+
+~~~sh
+lein test
+~~~
+
+To run tests with a 9k-based JRuby, run:
+
+~~~sh
+lein with-profile +jruby9k test
+~~~
 
 ## License
 

--- a/ext/travisci/test.sh
+++ b/ext/travisci/test.sh
@@ -1,3 +1,9 @@
 #!/bin/bash
 
+set -e
+
+echo "Running tests with default JRuby (1.7-based)"
 lein2 test
+
+echo "Running tests with JRuby 9k"
+lein2 with-profile +jruby9k test

--- a/project.clj
+++ b/project.clj
@@ -40,7 +40,8 @@
   :classifiers [["test" :testutils]]
 
   :profiles {:dev {:dependencies  [[puppetlabs/kitchensink :classifier "test" :scope "test"]
-                                   [puppetlabs/trapperkeeper :classifier "test" :scope "test"]]
+                                   [puppetlabs/trapperkeeper :classifier "test" :scope "test"]
+                                   [org.tcrawley/dynapath]]
                    :jvm-opts ["-Djruby.logger.class=com.puppetlabs.jruby_utils.jruby.Slf4jLogger"
                               "-Xms1G"
                               "-Xmx2G"]}

--- a/project.clj
+++ b/project.clj
@@ -41,7 +41,9 @@
 
   :profiles {:dev {:dependencies  [[puppetlabs/kitchensink :classifier "test" :scope "test"]
                                    [puppetlabs/trapperkeeper :classifier "test" :scope "test"]]
-                   :jvm-opts ["-Djruby.logger.class=com.puppetlabs.jruby_utils.jruby.Slf4jLogger"]}
+                   :jvm-opts ["-Djruby.logger.class=com.puppetlabs.jruby_utils.jruby.Slf4jLogger"
+                              "-Xms1G"
+                              "-Xmx2G"]}
              :testutils {:source-paths ^:replace ["test/unit" "test/integration"]}
              :jruby9k {:dependencies [[puppetlabs/jruby-deps "9.1.8.0-1"]]}}
 

--- a/project.clj
+++ b/project.clj
@@ -21,18 +21,7 @@
                  [prismatic/schema]
                  [slingshot]
 
-                 [org.jruby/jruby-core "1.7.26"
-                  :exclusions [com.github.jnr/jffi com.github.jnr/jnr-x86asm]]
-                 ;; jffi and jnr-x86asm are explicit dependencies because,
-                 ;; in JRuby's poms, they are defined using version ranges,
-                 ;; and :pedantic? :abort won't tolerate this.
-                 [com.github.jnr/jffi "1.2.12"]
-                 [com.github.jnr/jffi "1.2.12" :classifier "native"]
-                 [com.github.jnr/jnr-x86asm "1.0.2"]
-                 ;; NOTE: jruby-stdlib packages some unexpected things inside
-                 ;; of its jar; please read the detailed notes above the
-                 ;; 'uberjar-exclusions' example toward the end of this file.
-                 [org.jruby/jruby-stdlib "1.7.26"]
+                 [puppetlabs/jruby-deps "1.7.26-1"]
 
                  [puppetlabs/i18n]
                  [puppetlabs/kitchensink]
@@ -53,7 +42,8 @@
   :profiles {:dev {:dependencies  [[puppetlabs/kitchensink :classifier "test" :scope "test"]
                                    [puppetlabs/trapperkeeper :classifier "test" :scope "test"]]
                    :jvm-opts ["-Djruby.logger.class=com.puppetlabs.jruby_utils.jruby.Slf4jLogger"]}
-             :testutils {:source-paths ^:replace ["test/unit" "test/integration"]}}
+             :testutils {:source-paths ^:replace ["test/unit" "test/integration"]}
+             :jruby9k {:dependencies [[puppetlabs/jruby-deps "9.1.8.0-1"]]}}
 
   :plugins [[lein-parent "0.3.1"]
             [puppetlabs/i18n "0.7.1"]])

--- a/src/clj/puppetlabs/services/jruby_pool_manager/impl/jruby_internal.clj
+++ b/src/clj/puppetlabs/services/jruby_pool_manager/impl/jruby_internal.clj
@@ -42,11 +42,7 @@
   (case compat-version
     "1.9" (CompatVersion/RUBY1_9)
     "2.0" (CompatVersion/RUBY2_0)
-    (throw (IllegalArgumentException.
-            (format "%s %s"
-                    (i18n/trs "compat-version is set to `{0}`, which is not an allowed option."
-                              compat-version)
-                    (i18n/trs "The available compat-versions are `1.9` and `2.0`"))))))
+    nil))
 
 (schema/defn ^:always-validate init-jruby :- jruby-schemas/ConfigurableJRuby
   "Applies configuration to a JRuby... thing.  See comments in `ConfigurableJRuby`
@@ -57,8 +53,9 @@
         initialize-scripting-container-fn (:initialize-scripting-container lifecycle)]
     (doto jruby
       (.setLoadPaths ruby-load-path)
-      (.setCompatVersion (get-compat-version compat-version))
       (.setCompileMode (get-compile-mode compile-mode)))
+    (when-let [compat-version (get-compat-version compat-version)]
+      (.setCompatVersion jruby compat-version))
     (initialize-scripting-container-fn jruby config)))
 
 (schema/defn ^:always-validate empty-scripting-container :- ScriptingContainer

--- a/src/clj/puppetlabs/services/jruby_pool_manager/jruby_schemas.clj
+++ b/src/clj/puppetlabs/services/jruby_pool_manager/jruby_schemas.clj
@@ -3,7 +3,8 @@
   (:import (clojure.lang Atom Agent IFn PersistentArrayMap PersistentHashMap)
            (com.puppetlabs.jruby_utils.pool LockablePool)
            (org.jruby Main Main$Status RubyInstanceConfig)
-           (com.puppetlabs.jruby_utils.jruby ScriptingContainer)))
+           (com.puppetlabs.jruby_utils.jruby ScriptingContainer InternalScriptingContainer)
+           (org.jruby.runtime Constants)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Schemas
@@ -33,11 +34,17 @@
   "Schema defining the supported values for the JRuby CompileMode setting."
   (apply schema/enum supported-jruby-compile-modes))
 
+(def using-jruby-9k?
+  (let [jruby-version Constants/VERSION]
+    (= "9." (subs jruby-version 0 2))))
+
 (def supported-jruby-compat-versions
-  #{"1.9" "2.0"})
+  (if using-jruby-9k?
+    #{Constants/RUBY_VERSION}
+    #{"1.9" "2.0"}))
 
 (def SupportedJRubyCompatVersions
-  "Schema defining the supported compatability versions for the JRuby CompatVersions setting"
+  "Schema defining the supported compatibility versions for the JRuby CompatVersions setting"
   (apply schema/enum supported-jruby-compat-versions))
 
 (def LifecycleFns

--- a/src/java/com/puppetlabs/jruby_utils/jruby/InternalScriptingContainer.java
+++ b/src/java/com/puppetlabs/jruby_utils/jruby/InternalScriptingContainer.java
@@ -2,6 +2,17 @@ package com.puppetlabs.jruby_utils.jruby;
 
 import org.jruby.embed.LocalContextScope;
 import org.jruby.embed.LocalVariableBehavior;
+import org.jruby.util.JRubyClassLoader;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.net.URL;
+import java.util.Map;
 
 /**
  * An extension of the JRuby ScriptingContainer class which is
@@ -10,12 +21,150 @@ import org.jruby.embed.LocalVariableBehavior;
 public class InternalScriptingContainer
         extends org.jruby.embed.ScriptingContainer
         implements ScriptingContainer {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(
+            InternalScriptingContainer.class);
+
+    /**
+     * {@link #terminateJarIndexCacheEntries(URL[])} method for more info on the
+     * purpose of the jar index cache purge code
+     */
+    private static Map<String, Object> jarIndexCache = null;
+    private static Method jarIndexReleaseMethod = null;
+    private static Exception jarIndexCacheException = null;
+    private static Method classLoaderTempDirMethod = null;
+
+    /**
+     * We have to use reflection to get access to the jar index cache since it
+     * is not public.
+     */
+    static {
+        try {
+            Class jarResourceClass = Class.forName("org.jruby.util.JarResource");
+            Field jarCacheField = jarResourceClass.getDeclaredField("jarCache");
+            jarCacheField.setAccessible(true);
+            Object jarCache = jarCacheField.get(jarResourceClass);
+            Class jarCacheClass = jarCache.getClass();
+            Field indexCacheField = jarCacheClass.getDeclaredField("indexCache");
+            indexCacheField.setAccessible(true);
+
+            @SuppressWarnings("unchecked") Map<String, Object> indexCache =
+                    (Map<String, Object>) indexCacheField.get(jarCache);
+            jarIndexCache = indexCache;
+
+            Class<?> jarIndexClass = Class.forName("org.jruby.util.JarCache$JarIndex");
+            jarIndexReleaseMethod = jarIndexClass.getMethod("release");
+            jarIndexReleaseMethod.setAccessible(true);
+
+            classLoaderTempDirMethod = JRubyClassLoader.class.getDeclaredMethod(
+                    "getTempDir");
+            classLoaderTempDirMethod.setAccessible(true);
+        } catch (ClassNotFoundException|
+                NoSuchFieldException|
+                NoSuchMethodException|
+                IllegalAccessException ex) {
+            jarIndexCacheException = ex;
+        }
+    }
+
+    private String classLoaderTempDir = null;
+
     public InternalScriptingContainer(LocalContextScope scope) {
         super(scope);
+        validateJarCacheAccess();
     }
+
     public InternalScriptingContainer(LocalContextScope scope,
                                       LocalVariableBehavior behavior) {
         super(scope, behavior);
+        validateJarCacheAccess();
+    }
+
+    private void validateJarCacheAccess() {
+        if (jarIndexCache == null || jarIndexReleaseMethod == null ||
+                classLoaderTempDirMethod == null) {
+            throw new RuntimeException(
+                    "Unable to access jar index cache", jarIndexCacheException);
+        }
+    }
+
+    private String getClassLoaderTempDir() {
+        File classLoaderTempDirAsFile = null;
+
+        try {
+            classLoaderTempDirAsFile = (File)
+                    classLoaderTempDirMethod.invoke(getJRubyClassLoader());
+            classLoaderTempDir = classLoaderTempDirAsFile.getPath();
+        } catch (IllegalAccessException|InvocationTargetException ex) {
+            throw new RuntimeException(
+                    "Unable to get temp directory for jruby classloader", ex);
+        }
+
+        return classLoaderTempDirAsFile.getPath();
+    }
+
+    private void removeJarIfTemp(String urlPath, String tempDir) {
+        // In JRuby 9k, when the JRubyClassLoader for a ScriptingContainer loads
+        // jars within jars, it ends up copying the original jar to a file under
+        // a temp directory.  See:
+        // https://github.com/jruby/jruby/blob/9.1.8.0/core/src/main/java/org/jruby/util/JRubyClassLoader.java#L78-L89.
+        // To avoid letting these temporary jars pile up on disk after the
+        // container has been terminated, the jars are deleted here.  The code
+        // below avoids deleting any jar not underneath the temp directory
+        // created for the class loader since that is more likely intended to be
+        // persistent.
+        if (urlPath.startsWith(classLoaderTempDir)) {
+            File urlPathAsFile = new File(urlPath);
+            if (!urlPathAsFile.delete()) {
+                LOGGER.warn("Unable to delete jar on container termination: {}",
+                        urlPathAsFile);
+            }
+        }
+    }
+
+    private JRubyClassLoader getJRubyClassLoader() {
+        return getProvider().getRuntime().getJRubyClassLoader();
+    }
+
+    /**
+     * When a ScriptingContainer is initialized under JRuby 9k, embedded jars
+     * like jopenssl and psych are copied out to a per-container temporary
+     * directory.  File descriptors are opened to the temporary jars and loaded
+     * into a static JarCache.  Entries added into the JarCache are not freed
+     * when the ScriptingContainer for which the entries are added is terminated.
+     * This leads to both the jar files on disk and associated file descriptors
+     * in memory piling up as containers are recycled.
+     *
+     * See https://github.com/jruby/jruby/issues/3928.
+     *
+     * Ideally, the jar files and descriptors would be cleaned up automatically
+     * by JRuby.  In lieu of that, we clean those up here, using some ugly code
+     * which accesses private functionality in JRuby.  Hopefully, we'll be able
+     * to remove this code later on when a fix is available in JRuby.
+     * https://tickets.puppetlabs.com/browse/SERVER-1777 describes the work
+     * for investigating a longer-term fix.
+     *
+     * Although the JarCache code exists both in JRuby 1.7 and 9k, entries only
+     * appear to be added per-container to the JarCache in JRuby 9k, so this
+     * code appears to basically be a no-op in JRuby 1.7.
+     */
+    private void terminateJarIndexCacheEntries(URL[] classLoaderUrls) {
+        String classLoaderTempDir = getClassLoaderTempDir();
+
+        for (URL classLoaderUrl : classLoaderUrls) {
+            String urlPath = classLoaderUrl.getPath();
+            Object jarEntry = jarIndexCache.get(urlPath);
+            if (jarEntry != null) {
+                jarIndexCache.remove(urlPath);
+                try {
+                    jarIndexReleaseMethod.invoke(jarEntry);
+                } catch (IllegalAccessException|InvocationTargetException ex) {
+                    throw new RuntimeException(
+                            "Unable to release jar index cache entry", ex);
+                }
+                removeJarIfTemp(urlPath, classLoaderTempDir);
+            }
+        }
     }
 
     /**
@@ -24,14 +173,21 @@ public class InternalScriptingContainer
      * many of which have overlapping arities.  This sometimes causes problems
      * with Clojure attempting to determine the correct signature to call.
      *
-     * @param receiver - the Ruby object to call a method on
+     * @param receiver   - the Ruby object to call a method on
      * @param methodName - the name of the method to call
-     * @param args - an array of args to call the method with
+     * @param args       - an array of args to call the method with
      * @param returnType - the expected type of the return value from the method call
      * @return - the result of calling the method on the Ruby receiver object
      */
     public Object callMethodWithArgArray(Object receiver, String methodName,
                                          Object[] args, Class<? extends Object> returnType) {
         return callMethod(receiver, methodName, args, returnType);
+    }
+
+    @Override
+    public void terminate() {
+        URL[] classLoaderUrls = getJRubyClassLoader().getURLs();
+        super.terminate();
+        terminateJarIndexCacheEntries(classLoaderUrls);
     }
 }

--- a/test/integration/puppetlabs/services/jruby_pool_manager/jruby_internal_test.clj
+++ b/test/integration/puppetlabs/services/jruby_pool_manager/jruby_internal_test.clj
@@ -2,7 +2,8 @@
   (:require [clojure.test :refer :all]
             [puppetlabs.services.jruby-pool-manager.impl.jruby-internal :as jruby-internal]
             [puppetlabs.services.jruby-pool-manager.jruby-testutils :as jruby-testutils]
-            [puppetlabs.services.jruby-pool-manager.jruby-schemas :as jruby-schemas])
+            [puppetlabs.services.jruby-pool-manager.jruby-schemas :as jruby-schemas]
+            [puppetlabs.trapperkeeper.testutils.logging :as logutils])
   (:import (com.puppetlabs.jruby_utils.pool JRubyPool)
            (org.jruby RubyInstanceConfig$CompileMode CompatVersion)
            (clojure.lang ExceptionInfo)))
@@ -27,11 +28,12 @@
                  (jruby-internal/get-compile-mode :foo)))))
 
 (deftest ^:integration settings-plumbed-into-jruby-container
-  (testing "setting plumbed into jruby container for"
+  (testing "settings plumbed into jruby container"
     (let [pool (JRubyPool. 1)
-          config (jruby-testutils/jruby-config
-                  {:compile-mode :jit
-                   :compat-version 2.0})
+          config (logutils/with-test-logging
+                  (jruby-testutils/jruby-config
+                   {:compile-mode :jit
+                    :compat-version 2.0}))
           instance (jruby-internal/create-pool-instance! pool 0 config #())
           container (:scripting-container instance)]
       (try

--- a/test/integration/puppetlabs/services/jruby_pool_manager/jruby_internal_test.clj
+++ b/test/integration/puppetlabs/services/jruby_pool_manager/jruby_internal_test.clj
@@ -3,6 +3,7 @@
             [puppetlabs.services.jruby-pool-manager.impl.jruby-internal :as jruby-internal]
             [puppetlabs.services.jruby-pool-manager.jruby-testutils :as jruby-testutils]
             [puppetlabs.services.jruby-pool-manager.jruby-schemas :as jruby-schemas]
+            [puppetlabs.services.jruby-pool-manager.jruby-core :as jruby-core]
             [puppetlabs.trapperkeeper.testutils.logging :as logutils])
   (:import (com.puppetlabs.jruby_utils.pool JRubyPool)
            (org.jruby RubyInstanceConfig$CompileMode CompatVersion)
@@ -45,13 +46,14 @@
 
 (deftest get-compat-version-test
   (testing "returns correct compat version for SupportedJrubyCompatVersions enum"
-    (is (.is1_9 (jruby-internal/get-compat-version "1.9")))
-    (is (not (.is2_0 (jruby-internal/get-compat-version "1.9"))))
-    (is (.is2_0 (jruby-internal/get-compat-version "2.0"))))
-  (testing "returns a valid CompatVersion for all values of enum"
-    (doseq [version jruby-schemas/supported-jruby-compat-versions]
-      (is (instance? CompatVersion
-                     (jruby-internal/get-compat-version version)))))
+    (when (contains? jruby-schemas/supported-jruby-compat-versions "1.9")
+      (is (= CompatVersion/RUBY1_9 (jruby-internal/get-compat-version "1.9"))))
+    (when (contains? jruby-schemas/supported-jruby-compat-versions "2.0")
+      (is (= CompatVersion/RUBY2_0 (jruby-internal/get-compat-version "2.0"))))
+    (when-not (contains? jruby-schemas/supported-jruby-compat-versions
+                         jruby-core/default-jruby-compat-version)
+      (is (nil? (jruby-internal/get-compat-version
+                 jruby-core/default-jruby-compat-version)))))
   (testing "throws an exception if mode is nil"
     (is (thrown? ExceptionInfo
                  (jruby-internal/get-compat-version nil))))

--- a/test/integration/puppetlabs/services/jruby_pool_manager/jruby_locking_test.clj
+++ b/test/integration/puppetlabs/services/jruby_pool_manager/jruby_locking_test.clj
@@ -1,11 +1,8 @@
 (ns puppetlabs.services.jruby-pool-manager.jruby-locking-test
   (:require [clojure.test :refer :all]
             [puppetlabs.services.jruby-pool-manager.jruby-testutils :as jruby-testutils]
-            [puppetlabs.trapperkeeper.app :as tk-app]
             [schema.test :as schema-test]
-            [puppetlabs.services.jruby-pool-manager.jruby-core :as jruby-core]
-            [puppetlabs.trapperkeeper.testutils.bootstrap :as tk-bootstrap]
-            [puppetlabs.services.protocols.pool-manager :as pool-manager-protocol])
+            [puppetlabs.services.jruby-pool-manager.jruby-core :as jruby-core])
   (:import (java.util.concurrent TimeoutException)))
 
 (use-fixtures :once schema-test/validate-schemas)
@@ -24,122 +21,106 @@
         true))))
 
 (deftest ^:integration with-lock-test
-  (tk-bootstrap/with-app-with-config
-   app
+  (jruby-testutils/with-pool-context
+   pool-context
    jruby-testutils/default-services
-   {}
-   (let [config (jruby-test-config 1)
-         pool-manager-service (tk-app/get-service app :PoolManagerService)
-         pool-context (pool-manager-protocol/create-pool pool-manager-service config)]
-     (jruby-testutils/wait-for-jrubies-from-pool-context pool-context)
-     (testing "initial state of write lock is unlocked"
-       (is (can-borrow-from-different-thread? pool-context))
-       (testing "with-lock macro holds write lock while executing body"
-         (jruby-core/with-lock
-          pool-context
-          :with-lock-holds-lock-test
-          (is (not (can-borrow-from-different-thread? pool-context)))))
-       (testing "with-lock macro releases write lock after exectuing body"
-         (is (can-borrow-from-different-thread? pool-context)))))))
+   (jruby-test-config 1)
+   (jruby-testutils/wait-for-jrubies-from-pool-context pool-context)
+   (testing "initial state of write lock is unlocked"
+     (is (can-borrow-from-different-thread? pool-context))
+     (testing "with-lock macro holds write lock while executing body"
+       (jruby-core/with-lock
+        pool-context
+        :with-lock-holds-lock-test
+        (is (not (can-borrow-from-different-thread? pool-context)))))
+     (testing "with-lock macro releases write lock after exectuing body"
+       (is (can-borrow-from-different-thread? pool-context))))))
 
 (deftest ^:integration with-lock-exception-test
-  (tk-bootstrap/with-app-with-config
-   app
+  (jruby-testutils/with-pool-context
+   pool-context
    jruby-testutils/default-services
-   {}
-   (let [config (jruby-test-config 1)
-         pool-manager-service (tk-app/get-service app :PoolManagerService)
-         pool-context (pool-manager-protocol/create-pool pool-manager-service config)]
-     (jruby-testutils/wait-for-jrubies-from-pool-context pool-context)
-     (testing "initial state of write lock is unlocked"
-       (is (can-borrow-from-different-thread? pool-context)))
+   (jruby-test-config 1)
+   (jruby-testutils/wait-for-jrubies-from-pool-context pool-context)
+   (testing "initial state of write lock is unlocked"
+     (is (can-borrow-from-different-thread? pool-context)))
 
-     (testing "with-lock macro releases lock even if body throws exception"
-       (is (thrown? IllegalStateException
-                    (jruby-core/with-lock pool-context :with-lock-exception-test
-                                          (is (not (can-borrow-from-different-thread?
-                                              pool-context)))
-                                          (throw (IllegalStateException. "exception")))))
-       (is (can-borrow-from-different-thread? pool-context))))))
+   (testing "with-lock macro releases lock even if body throws exception"
+     (is (thrown? IllegalStateException
+                  (jruby-core/with-lock pool-context :with-lock-exception-test
+                                        (is (not (can-borrow-from-different-thread?
+                                                  pool-context)))
+                                        (throw (IllegalStateException. "exception")))))
+     (is (can-borrow-from-different-thread? pool-context)))))
 
 (deftest ^:integration with-lock-event-notification-test
   (testing "locking sends event notifications"
     (let [events (atom [])
           callback (fn [{:keys [type]}]
                      (swap! events conj type))]
-      (tk-bootstrap/with-app-with-config
-        app
+      (jruby-testutils/with-pool-context
+        pool-context
         jruby-testutils/default-services
-        {}
-        (let [config (jruby-test-config 1)
-              pool-manager-service (tk-app/get-service app :PoolManagerService)
-              pool-context (pool-manager-protocol/create-pool pool-manager-service config)]
-          (jruby-testutils/wait-for-jrubies-from-pool-context pool-context)
-          (jruby-core/register-event-handler pool-context callback)
+        (jruby-test-config 1)
+        (jruby-testutils/wait-for-jrubies-from-pool-context pool-context)
+        (jruby-core/register-event-handler pool-context callback)
 
-          (testing "locking events trigger event notifications"
-            (jruby-core/with-jruby-instance
-             jruby-instance
-             pool-context
-             :with-lock-events-test
-             (testing "borrowing a jruby triggers 'requested'/'borrow' events"
-               (is (= [:instance-requested :instance-borrowed] @events))))
-            (testing "returning a jruby triggers 'returned' event"
-              (is (= [:instance-requested :instance-borrowed :instance-returned] @events)))
-            (jruby-core/with-lock
-             pool-context
-             :with-lock-events-test
-             (testing "acquiring a lock triggers 'lock-requested'/'lock-acquired' events"
-               (is (= [:instance-requested :instance-borrowed :instance-returned
-                       :lock-requested :lock-acquired] @events)))))
-          (testing "releasing the lock triggers 'lock-released' event"
-            (is (= [:instance-requested :instance-borrowed :instance-returned
-                    :lock-requested :lock-acquired :lock-released] @events))))))))
+        (testing "locking events trigger event notifications"
+          (jruby-core/with-jruby-instance
+           jruby-instance
+           pool-context
+           :with-lock-events-test
+           (testing "borrowing a jruby triggers 'requested'/'borrow' events"
+             (is (= [:instance-requested :instance-borrowed] @events))))
+          (testing "returning a jruby triggers 'returned' event"
+            (is (= [:instance-requested :instance-borrowed :instance-returned] @events)))
+          (jruby-core/with-lock
+           pool-context
+           :with-lock-events-test
+           (testing "acquiring a lock triggers 'lock-requested'/'lock-acquired' events"
+             (is (= [:instance-requested :instance-borrowed :instance-returned
+                     :lock-requested :lock-acquired] @events)))))
+        (testing "releasing the lock triggers 'lock-released' event"
+          (is (= [:instance-requested :instance-borrowed :instance-returned
+                  :lock-requested :lock-acquired :lock-released] @events)))))))
 
 (deftest ^:integration with-lock-and-borrow-contention-test
   (testing "contention for instances with borrows and locking handled properly"
-    (tk-bootstrap/with-app-with-config
-     app
+    (jruby-testutils/with-pool-context
+     pool-context
      jruby-testutils/default-services
-     {}
-     (let [config (jruby-test-config 2)
-           pool-manager-service (tk-app/get-service app :PoolManagerService)
-           pool-context (pool-manager-protocol/create-pool pool-manager-service config)]
-       (jruby-testutils/wait-for-jrubies-from-pool-context pool-context)
-       (let [instance (jruby-core/borrow-from-pool-with-timeout
-                       pool-context
-                       :with-lock-and-borrow-contention-test
-                       [])
-             lock-acquired? (promise)
-             unlock-thread? (promise)
-             lock-thread (future (jruby-core/with-lock
-                                  pool-context
-                                  :with-lock-and-borrow-contention-test
-                                  (deliver lock-acquired? true)
-                                  @unlock-thread?))]
-         (testing "lock not granted yet when instance still borrowed"
-           (is (not (realized?
-                     lock-acquired?))))
-         (jruby-core/return-to-pool instance :with-lock-and-borrow-contention-test [])
-         @lock-acquired?
-         (testing "cannot borrow from non-locking thread when locked"
-           (is (not (can-borrow-from-different-thread? pool-context))))
-         (deliver unlock-thread? true)
-         @lock-thread
-         (testing "can borrow from non-locking thread after lock released"
-           (is (can-borrow-from-different-thread? pool-context))))))))
+     (jruby-test-config 2)
+     (jruby-testutils/wait-for-jrubies-from-pool-context pool-context)
+     (let [instance (jruby-core/borrow-from-pool-with-timeout
+                     pool-context
+                     :with-lock-and-borrow-contention-test
+                     [])
+           lock-acquired? (promise)
+           unlock-thread? (promise)
+           lock-thread (future (jruby-core/with-lock
+                                pool-context
+                                :with-lock-and-borrow-contention-test
+                                (deliver lock-acquired? true)
+                                @unlock-thread?))]
+       (testing "lock not granted yet when instance still borrowed"
+         (is (not (realized?
+                   lock-acquired?))))
+       (jruby-core/return-to-pool instance :with-lock-and-borrow-contention-test [])
+       @lock-acquired?
+       (testing "cannot borrow from non-locking thread when locked"
+         (is (not (can-borrow-from-different-thread? pool-context))))
+       (deliver unlock-thread? true)
+       @lock-thread
+       (testing "can borrow from non-locking thread after lock released"
+         (is (can-borrow-from-different-thread? pool-context)))))))
 
 (deftest ^:integration with-lock-with-timeout-test
   (testing "can obtain lock when timeout is not exceeded"
-    (tk-bootstrap/with-app-with-config
-     app
+    (jruby-testutils/with-pool-context
+     pool-context
      jruby-testutils/default-services
-     {}
-     (let [config (jruby-test-config 1)
-           pool-manager-service (tk-app/get-service app :PoolManagerService)
-           pool-context (pool-manager-protocol/create-pool pool-manager-service config)
-           pool (jruby-core/get-pool pool-context)]
-
+     (jruby-test-config 1)
+     (let [pool (jruby-core/get-pool pool-context)]
        (jruby-core/with-lock-with-timeout
         pool-context
         10000000
@@ -148,28 +129,29 @@
        (is (not (.isLocked pool))))))
 
   (testing "TimeoutException thrown when lock timeout is exceeded"
-    (tk-bootstrap/with-app-with-config
-     app
+    (jruby-testutils/with-pool-context
+     pool-context
      jruby-testutils/default-services
-     {}
-     (let [config (jruby-test-config 1)
-           pool-manager-service (tk-app/get-service app :PoolManagerService)
-           pool-context (pool-manager-protocol/create-pool pool-manager-service config)
-           pool (jruby-core/get-pool pool-context)
+     (jruby-test-config 1)
+     (let [pool (jruby-core/get-pool pool-context)
            borrowed-instance (jruby-core/borrow-from-pool
                               pool-context
                               :lock-timeout-exceeded-test
                               [])]
-
-       ; Since an instance has been borrowed the lock won't be granted and should
-       ; trigger the timeout immediately
-       (is (thrown-with-msg?
-            TimeoutException
-            #"Timeout limit reached before lock could be granted"
-            (jruby-core/with-lock-with-timeout
-             pool-context
-             1
-             :lock-timeout-exceeded-test
-             ; should not reach here
-             (is false))))
-       (is (not (.isLocked pool)))))))
+       (try
+         ; Since an instance has been borrowed the lock won't be granted and should
+         ; trigger the timeout immediately
+         (is (thrown-with-msg?
+              TimeoutException
+              #"Timeout limit reached before lock could be granted"
+              (jruby-core/with-lock-with-timeout
+               pool-context
+               1
+               :lock-timeout-exceeded-test
+               ; should not reach here
+               (is false))))
+         (is (not (.isLocked pool)))
+         (finally
+           (jruby-core/return-to-pool borrowed-instance
+                                      :lock-timeout-exceeded-test
+                                      [])))))))

--- a/test/unit/puppetlabs/services/jruby_pool_manager/jruby_agents_test.clj
+++ b/test/unit/puppetlabs/services/jruby_pool_manager/jruby_agents_test.clj
@@ -1,13 +1,10 @@
 (ns puppetlabs.services.jruby-pool-manager.jruby-agents-test
   (:require [clojure.test :refer :all]
             [schema.test :as schema-test]
-            [puppetlabs.trapperkeeper.testutils.bootstrap :as tk-bootstrap]
             [puppetlabs.services.jruby-pool-manager.jruby-testutils :as jruby-testutils]
             [puppetlabs.services.jruby-pool-manager.jruby-core :as jruby-core]
-            [puppetlabs.trapperkeeper.app :as tk-app]
             [puppetlabs.services.jruby-pool-manager.impl.jruby-agents :as jruby-agents]
-            [puppetlabs.services.jruby-pool-manager.impl.jruby-pool-manager-core :as jruby-pool-manager-core]
-            [puppetlabs.services.protocols.pool-manager :as pool-manager-protocol])
+            [puppetlabs.services.jruby-pool-manager.impl.jruby-pool-manager-core :as jruby-pool-manager-core])
   (:import (puppetlabs.services.jruby_pool_manager.jruby_schemas JRubyInstance)))
 
 (use-fixtures :once schema-test/validate-schemas)
@@ -28,28 +25,26 @@
           config (assoc-in (jruby-testutils/jruby-config {:max-active-instances 1})
                            [:lifecycle :cleanup]
                            (fn [x] (reset! cleanup-atom "Hello from cleanup")))]
-      (tk-bootstrap/with-app-with-config
-       app
+      (jruby-testutils/with-pool-context
+       pool-context
        jruby-testutils/default-services
-       {}
-       (let [pool-manager-service (tk-app/get-service app :PoolManagerService)
-             pool-context (pool-manager-protocol/create-pool pool-manager-service config)]
-         (jruby-core/flush-pool! pool-context)
-         ; wait until the flush is complete
-         (is (jruby-testutils/timed-await (jruby-agents/get-modify-instance-agent pool-context)))
-         (is (= "Hello from cleanup" (deref cleanup-atom))))))))
+       config
+       (jruby-core/flush-pool! pool-context)
+       ; wait until the flush is complete
+       (is (jruby-testutils/timed-await (jruby-agents/get-modify-instance-agent pool-context)))
+       (is (= "Hello from cleanup" (deref cleanup-atom)))))))
 
 (deftest collect-all-jrubies-test
   (testing "returns list of all the jruby instances"
-    (tk-bootstrap/with-app-with-config
-     app
+    (jruby-testutils/with-pool-context
+     pool-context
      jruby-testutils/default-services
-     {}
-     (let [config (jruby-testutils/jruby-config {:max-active-instances 4})
-           pool-manager-service (tk-app/get-service app :PoolManagerService)
-           pool-context (pool-manager-protocol/create-pool pool-manager-service config)
-           pool (jruby-core/get-pool pool-context)
+     (jruby-testutils/jruby-config {:max-active-instances 4})
+     (let [pool (jruby-core/get-pool pool-context)
            jruby-list (jruby-agents/borrow-all-jrubies pool-context)]
-       (is (= 4 (count jruby-list)))
-       (is (every? #(instance? JRubyInstance %) jruby-list))
-       (is (= 0 (.size pool)))))))
+       (try
+         (is (= 4 (count jruby-list)))
+         (is (every? #(instance? JRubyInstance %) jruby-list))
+         (is (= 0 (.size pool)))
+         (finally
+           (jruby-testutils/fill-drained-pool jruby-list)))))))

--- a/test/unit/puppetlabs/services/jruby_pool_manager/jruby_interpreter_test.clj
+++ b/test/unit/puppetlabs/services/jruby_pool_manager/jruby_interpreter_test.clj
@@ -1,32 +1,33 @@
 (ns puppetlabs.services.jruby-pool-manager.jruby-interpreter-test
   (:require [clojure.test :refer :all]
             [puppetlabs.services.jruby-pool-manager.jruby-testutils :as jruby-testutils]
-            [puppetlabs.services.jruby-pool-manager.impl.jruby-internal :as jruby-internal]
             [puppetlabs.services.jruby-pool-manager.jruby-core :as jruby-core]))
 
 (deftest jruby-env-vars
   (testing "the environment used by the JRuby interpreters"
-    (let [jruby-interpreter (jruby-internal/create-scripting-container
-                              (jruby-testutils/jruby-config))
-          jruby-env (.runScriptlet jruby-interpreter "ENV")]
-      ;; $HOME and $PATH are left in by `jruby-env`
-      ;; Note that other environment variables are allowed through (e.g.
-      ;; `HTTP_PROXY` - see jruby-core/env-vars-allowed-list for the full list),
-      ;; but are not expected to be set in most environments. However, in
-      ;; order to make this more test robust, these variables are always
-      ;; filtered out.
-      (is (= #{"HOME" "PATH" "GEM_HOME" "JARS_NO_REQUIRE" "JARS_REQUIRE" "RUBY"}
-             (set (remove (set jruby-core/proxy-vars-allowed-list) (keys jruby-env))))))))
+    (jruby-testutils/with-scripting-container
+     jruby-interpreter
+     (jruby-testutils/jruby-config)
+     (let [jruby-env (.runScriptlet jruby-interpreter "ENV")]
+       ;; $HOME and $PATH are left in by `jruby-env`
+       ;; Note that other environment variables are allowed through (e.g.
+       ;; `HTTP_PROXY` - see jruby-core/env-vars-allowed-list for the full list),
+       ;; but are not expected to be set in most environments. However, in
+       ;; order to make this more test robust, these variables are always
+       ;; filtered out.
+       (is (= #{"HOME" "PATH" "GEM_HOME" "JARS_NO_REQUIRE" "JARS_REQUIRE" "RUBY"}
+              (set (remove (set jruby-core/proxy-vars-allowed-list) (keys jruby-env)))))))))
 
 (deftest jruby-configured-env-vars
   (testing "the environment used by the JRuby interpreters can be added to via the config"
-    (let [jruby-interpreter (jruby-internal/create-scripting-container
-                             (jruby-testutils/jruby-config {:environment-vars {:FOO "for_jruby"}}))
-          jruby-env (.runScriptlet jruby-interpreter "ENV")]
-      ;; Note that other environment variables are allowed through,
-      ;; but are not expected to be set in most environments. However, in
-      ;; order to make this test more robust, these variables are always
-      ;; filtered out.
-      (is (= #{"HOME" "PATH" "GEM_HOME" "JARS_NO_REQUIRE" "JARS_REQUIRE" "FOO" "RUBY"}
-             (set (remove (set jruby-core/proxy-vars-allowed-list) (keys jruby-env)))))
-      (is (= (.get jruby-env "FOO") "for_jruby")))))
+    (jruby-testutils/with-scripting-container
+     jruby-interpreter
+     (jruby-testutils/jruby-config {:environment-vars {:FOO "for_jruby"}})
+     (let [jruby-env (.runScriptlet jruby-interpreter "ENV")]
+       ;; Note that other environment variables are allowed through,
+       ;; but are not expected to be set in most environments. However, in
+       ;; order to make this test more robust, these variables are always
+       ;; filtered out.
+       (is (= #{"HOME" "PATH" "GEM_HOME" "JARS_NO_REQUIRE" "JARS_REQUIRE" "FOO" "RUBY"}
+              (set (remove (set jruby-core/proxy-vars-allowed-list) (keys jruby-env)))))
+       (is (= (.get jruby-env "FOO") "for_jruby"))))))

--- a/test/unit/puppetlabs/services/jruby_pool_manager/jruby_pool_test.clj
+++ b/test/unit/puppetlabs/services/jruby_pool_manager/jruby_pool_test.clj
@@ -14,6 +14,11 @@
             [puppetlabs.services.jruby-pool-manager.impl.jruby-pool-manager-core :as jruby-pool-manager-core]
             [puppetlabs.services.jruby-pool-manager.jruby-schemas :as jruby-schemas]))
 
+(defn- initialize-jruby-config-with-logging-suppressed
+  [config]
+  (logutils/with-test-logging
+   (jruby-core/initialize-config config)))
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Tests
 
@@ -25,7 +30,8 @@
                             (jruby-pool-manager-core/create-pool-context malformed-config)))))
   (let [minimal-config {:gem-home "/dev/null"
                         :ruby-load-path ["/dev/null"]}
-        config        (jruby-core/initialize-config minimal-config)]
+        config        (initialize-jruby-config-with-logging-suppressed
+                       minimal-config)]
     (testing "max-active-instances is set to default if not specified"
       (is (= (jruby-core/default-pool-size (ks/num-cpus)) (:max-active-instances config))))
     (testing "max-borrows-per-instance is set to 0 if not specified"
@@ -33,7 +39,7 @@
     (testing "max-borrows-per-instance is honored if specified"
       (is (= 5 (-> minimal-config
                    (assoc :max-borrows-per-instance 5)
-                   (jruby-core/initialize-config)
+                   (initialize-jruby-config-with-logging-suppressed)
                    :max-borrows-per-instance))))
     (testing "compile-mode is set to default if not specified"
       (is (= jruby-core/default-jruby-compile-mode
@@ -41,11 +47,11 @@
     (testing "compile-mode is honored if specified"
       (is (= :off (-> minimal-config
                       (assoc :compile-mode "off")
-                      (jruby-core/initialize-config)
+                      (initialize-jruby-config-with-logging-suppressed)
                       :compile-mode)))
       (is (= :jit (-> minimal-config
                       (assoc :compile-mode "jit")
-                      (jruby-core/initialize-config)
+                      (initialize-jruby-config-with-logging-suppressed)
                       :compile-mode))))
     (testing "compat-version is set to default if not specified"
       (is (= jruby-core/default-jruby-compat-version
@@ -53,39 +59,39 @@
     (testing "compat-version is honored if specified as a string"
       (is (= "1.9" (-> minimal-config
                        (assoc :compat-version "1.9")
-                       (jruby-core/initialize-config)
+                       (initialize-jruby-config-with-logging-suppressed)
                        :compat-version)))
       (is (= "2.0" (-> minimal-config
                        (assoc :compat-version "2.0")
-                       (jruby-core/initialize-config)
+                       (initialize-jruby-config-with-logging-suppressed)
                        :compat-version))))
     (testing "compat-version is honored if specified as a double"
       ;; depending on how the setting is laid down in a HOCON file, it seems feasible that it might
       ;; be a string or a double. We should tolerate either.
       (is (= "1.9" (-> minimal-config
                        (assoc :compat-version 1.9)
-                       (jruby-core/initialize-config)
+                       (initialize-jruby-config-with-logging-suppressed)
                        :compat-version)))
       (is (= "2.0" (-> minimal-config
                        (assoc :compat-version 2.0)
-                       (jruby-core/initialize-config)
+                       (initialize-jruby-config-with-logging-suppressed)
                        :compat-version))))
     (testing "compat-version is honored if specified as an integer"
       ;; HOCON might parse doubles as integers in some cases? so we should tolerate it as an integer
       ;; too
       (is (= "2.0" (-> minimal-config
                        (assoc :compat-version 2)
-                       (jruby-core/initialize-config)
+                       (initialize-jruby-config-with-logging-suppressed)
                        :compat-version))))
     (testing "gem-path is set to nil if not specified"
       (is (nil? (-> minimal-config
-                    jruby-core/initialize-config
+                    initialize-jruby-config-with-logging-suppressed
                     :gem-path))))
     (testing "gem-path is respected if specified"
       (is (= "/tmp/foo:/dev/null"
              (-> minimal-config
                  (assoc :gem-path "/tmp/foo:/dev/null")
-                 jruby-core/initialize-config
+                 initialize-jruby-config-with-logging-suppressed
                  :gem-path))))))
 
 (deftest test-jruby-core-funcs

--- a/test/unit/puppetlabs/services/jruby_pool_manager/jruby_pool_test.clj
+++ b/test/unit/puppetlabs/services/jruby_pool_manager/jruby_pool_test.clj
@@ -29,7 +29,11 @@
   (let [minimal-config {:gem-home "/dev/null"
                         :ruby-load-path ["/dev/null"]}
         config        (initialize-jruby-config-with-logging-suppressed
-                       minimal-config)]
+                       minimal-config)
+        expected-version-fn (fn [version]
+                              (if (= (count jruby-schemas/supported-jruby-compat-versions) 1)
+                                jruby-core/default-jruby-compat-version
+                                version))]
     (testing "max-active-instances is set to default if not specified"
       (is (= (jruby-core/default-pool-size (ks/num-cpus)) (:max-active-instances config))))
     (testing "max-borrows-per-instance is set to 0 if not specified"
@@ -55,32 +59,37 @@
       (is (= jruby-core/default-jruby-compat-version
              (:compat-version config))))
     (testing "compat-version is honored if specified as a string"
-      (is (= "1.9" (-> minimal-config
-                       (assoc :compat-version "1.9")
-                       (initialize-jruby-config-with-logging-suppressed)
-                       :compat-version)))
-      (is (= "2.0" (-> minimal-config
-                       (assoc :compat-version "2.0")
-                       (initialize-jruby-config-with-logging-suppressed)
-                       :compat-version))))
+      (is (= (expected-version-fn "1.9")
+             (-> minimal-config
+                 (assoc :compat-version "1.9")
+                 (initialize-jruby-config-with-logging-suppressed)
+                 :compat-version)))
+      (is (= (expected-version-fn "2.0")
+             (-> minimal-config
+                 (assoc :compat-version "2.0")
+                 (initialize-jruby-config-with-logging-suppressed)
+                 :compat-version))))
     (testing "compat-version is honored if specified as a double"
       ;; depending on how the setting is laid down in a HOCON file, it seems feasible that it might
       ;; be a string or a double. We should tolerate either.
-      (is (= "1.9" (-> minimal-config
-                       (assoc :compat-version 1.9)
-                       (initialize-jruby-config-with-logging-suppressed)
-                       :compat-version)))
-      (is (= "2.0" (-> minimal-config
-                       (assoc :compat-version 2.0)
-                       (initialize-jruby-config-with-logging-suppressed)
-                       :compat-version))))
+      (is (= (expected-version-fn "1.9")
+             (-> minimal-config
+                 (assoc :compat-version 1.9)
+                 (initialize-jruby-config-with-logging-suppressed)
+                 :compat-version)))
+      (is (= (expected-version-fn "2.0")
+             (-> minimal-config
+                 (assoc :compat-version 2.0)
+                 (initialize-jruby-config-with-logging-suppressed)
+                 :compat-version))))
     (testing "compat-version is honored if specified as an integer"
       ;; HOCON might parse doubles as integers in some cases? so we should tolerate it as an integer
       ;; too
-      (is (= "2.0" (-> minimal-config
-                       (assoc :compat-version 2)
-                       (initialize-jruby-config-with-logging-suppressed)
-                       :compat-version))))
+      (is (= (expected-version-fn "2.0")
+             (-> minimal-config
+                 (assoc :compat-version 2)
+                 (initialize-jruby-config-with-logging-suppressed)
+                 :compat-version))))
     (testing "gem-path is set to nil if not specified"
       (is (nil? (-> minimal-config
                     initialize-jruby-config-with-logging-suppressed

--- a/test/unit/puppetlabs/services/jruby_pool_manager/jruby_pool_test.clj
+++ b/test/unit/puppetlabs/services/jruby_pool_manager/jruby_pool_test.clj
@@ -1,6 +1,4 @@
 (ns puppetlabs.services.jruby-pool-manager.jruby-pool-test
-  (:import (clojure.lang ExceptionInfo)
-           (puppetlabs.services.jruby_pool_manager.jruby_schemas ShutdownPoisonPill))
   (:require [clojure.test :refer :all]
             [puppetlabs.kitchensink.core :as ks]
             [puppetlabs.services.jruby-pool-manager.jruby-testutils :as jruby-testutils]
@@ -8,11 +6,11 @@
             [puppetlabs.services.jruby-pool-manager.jruby-core :as jruby-core]
             [puppetlabs.services.jruby-pool-manager.impl.jruby-internal :as jruby-internal]
             [puppetlabs.trapperkeeper.testutils.logging :as logutils]
-            [puppetlabs.trapperkeeper.testutils.bootstrap :as tk-bootstrap]
-            [puppetlabs.trapperkeeper.app :as tk-app]
-            [puppetlabs.services.protocols.pool-manager :as pool-manager-protocol]
             [puppetlabs.services.jruby-pool-manager.impl.jruby-pool-manager-core :as jruby-pool-manager-core]
-            [puppetlabs.services.jruby-pool-manager.jruby-schemas :as jruby-schemas]))
+            [puppetlabs.services.jruby-pool-manager.jruby-schemas :as jruby-schemas])
+  (:import (clojure.lang ExceptionInfo)
+           (puppetlabs.services.jruby_pool_manager.jruby_schemas ShutdownPoisonPill)))
+
 
 (defn- initialize-jruby-config-with-logging-suppressed
   [config]
@@ -101,117 +99,119 @@
                                                         :borrow-timeout timeout})
         pool-context (jruby-pool-manager-core/create-pool-context config)
         pool             (jruby-core/get-pool pool-context)]
-
     (testing "The pool should not yet be full as it is being primed in the
              background."
-      (is (= (jruby-core/free-instance-count pool) 0)))
+      (is (= (jruby-core/free-instance-count pool) 0))
 
-    (jruby-agents/prime-pool! pool-context)
-
-    (testing "Borrowing all instances from a pool while it is being primed and
+      (jruby-agents/prime-pool! pool-context)
+      (try
+        (testing "Borrowing all instances from a pool while it is being primed and
              returning them."
-      (let [all-the-jrubys (jruby-testutils/drain-pool pool-context pool-size)]
-        (is (= 0 (jruby-core/free-instance-count pool)))
-        (doseq [instance all-the-jrubys]
-          (is (not (nil? instance)) "One of JRubyInstances is nil"))
-        (jruby-testutils/fill-drained-pool all-the-jrubys)
-        (is (= pool-size (jruby-core/free-instance-count pool)))))
+          (let [all-the-jrubys (jruby-testutils/drain-pool pool-context pool-size)]
+            (is (= 0 (jruby-core/free-instance-count pool)))
+            (doseq [instance all-the-jrubys]
+              (is (not (nil? instance)) "One of JRubyInstances is nil"))
+            (jruby-testutils/fill-drained-pool all-the-jrubys)
+            (is (= pool-size (jruby-core/free-instance-count pool)))))
 
-    (testing "Borrowing from an empty pool with a timeout returns nil within the
+        (testing "Borrowing from an empty pool with a timeout returns nil within the
              proper amount of time."
-      (let [all-the-jrubys       (jruby-testutils/drain-pool pool-context pool-size)
-            test-start-in-millis (System/currentTimeMillis)]
-        (is (nil? (jruby-core/borrow-from-pool-with-timeout pool-context :test [])))
-        (is (>= (- (System/currentTimeMillis) test-start-in-millis) timeout)
-            "The timeout value was not honored.")
-        (jruby-testutils/fill-drained-pool all-the-jrubys)
-        (is (= (jruby-core/free-instance-count pool) pool-size)
-            "All JRubyInstances were not returned to the pool.")))
+          (let [all-the-jrubys (jruby-testutils/drain-pool pool-context pool-size)
+                test-start-in-millis (System/currentTimeMillis)]
+            (is (nil? (jruby-core/borrow-from-pool-with-timeout pool-context :test [])))
+            (is (>= (- (System/currentTimeMillis) test-start-in-millis) timeout)
+                "The timeout value was not honored.")
+            (jruby-testutils/fill-drained-pool all-the-jrubys)
+            (is (= (jruby-core/free-instance-count pool) pool-size)
+                "All JRubyInstances were not returned to the pool.")))
 
-    (testing "Removing an instance decrements the pool size by 1."
-      (let [jruby-instance (jruby-core/borrow-from-pool pool-context :test [])]
-        (is (= (jruby-core/free-instance-count pool) (dec pool-size)))
-        (jruby-core/return-to-pool jruby-instance :test [])))
+        (testing "Removing an instance decrements the pool size by 1."
+          (let [jruby-instance (jruby-core/borrow-from-pool pool-context :test [])]
+            (is (= (jruby-core/free-instance-count pool) (dec pool-size)))
+            (jruby-core/return-to-pool jruby-instance :test [])))
 
-    (testing "Borrowing an instance increments its request count."
-      (let [drain-via   (fn [borrow-fn] (doall (repeatedly pool-size borrow-fn)))
-            assoc-count (fn [acc jruby]
-                          (assoc acc (:id jruby)
-                                     (:borrow-count (jruby-core/get-instance-state jruby))))
-            get-counts  (fn [jrubies] (reduce assoc-count {} jrubies))]
-        (doseq [drain-fn [#(jruby-core/borrow-from-pool pool-context :test [])
-                          #(jruby-core/borrow-from-pool-with-timeout pool-context :test [])]]
-          (let [jrubies (drain-via drain-fn)
-                counts  (get-counts jrubies)]
-            (jruby-testutils/fill-drained-pool jrubies)
-            (let [jrubies    (drain-via drain-fn)
-                  new-counts (get-counts jrubies)]
-              (jruby-testutils/fill-drained-pool jrubies)
-              (is (= (ks/keyset counts) (ks/keyset new-counts)))
-              (doseq [k (keys counts)]
-                (is (= (inc (counts k)) (new-counts k)))))))))))
+        (testing "Borrowing an instance increments its request count."
+          (let [drain-via (fn [borrow-fn] (doall (repeatedly pool-size borrow-fn)))
+                assoc-count (fn [acc jruby]
+                              (assoc acc (:id jruby)
+                                         (:borrow-count (jruby-core/get-instance-state jruby))))
+                get-counts (fn [jrubies] (reduce assoc-count {} jrubies))]
+            (doseq [drain-fn [#(jruby-core/borrow-from-pool pool-context :test [])
+                              #(jruby-core/borrow-from-pool-with-timeout pool-context :test [])]]
+              (let [jrubies (drain-via drain-fn)
+                    counts (get-counts jrubies)]
+                (jruby-testutils/fill-drained-pool jrubies)
+                (let [jrubies (drain-via drain-fn)
+                      new-counts (get-counts jrubies)]
+                  (jruby-testutils/fill-drained-pool jrubies)
+                  (is (= (ks/keyset counts) (ks/keyset new-counts)))
+                  (doseq [k (keys counts)]
+                    (is (= (inc (counts k)) (new-counts k)))))))))
+        (finally
+          (jruby-core/flush-pool-for-shutdown! pool-context))))))
 
 (deftest borrow-while-pool-is-being-initialized-test
   (testing "borrow will block until an instance is available while the pool is coming online"
-    (tk-bootstrap/with-app-with-config
-     app
-     jruby-testutils/default-services
-     {}
     (let [pool-initialized? (promise)
           init-fn (fn [instance] @pool-initialized? instance)
-          pool-size 1
-          config (jruby-testutils/jruby-config
-                  {:max-active-instances pool-size
-                   :lifecycle {:initialize-pool-instance init-fn}})
-          pool-manager-service (tk-app/get-service app :PoolManagerService)
-          ;; start a pool initialization, which will block on the `initialize-pool-instance`
-          ;; function's deref of the promise
-          pool-context (pool-manager-protocol/create-pool pool-manager-service config)]
+          pool-size 1]
+     ;; start a pool initialization, which will block on the `initialize-pool-instance`
+     ;; function's deref of the promise
+     (jruby-testutils/with-pool-context
+      pool-context
+      jruby-testutils/default-services
+      (jruby-testutils/jruby-config
+       {:max-active-instances pool-size
+        :lifecycle {:initialize-pool-instance init-fn}})
 
       ;; start a borrow, which should block until an instance becomes available
       (let [borrow-instance (future (jruby-core/borrow-from-pool-with-timeout
                                      pool-context
                                      :borrow-during-pool-init-test
                                      []))]
+        (try
+          (is (not (realized? borrow-instance)))
 
-        (is (not (realized? borrow-instance)))
+          ;; deliver the promise, allowing the pool initialization to complete
+          (deliver pool-initialized? true)
 
-        ;; deliver the promise, allowing the pool initialization to complete
-        (deliver pool-initialized? true)
-
-        ;; now the borrow can complete
-        (is (jruby-schemas/jruby-instance? @borrow-instance)))))))
+          ;; now the borrow can complete
+          (is (jruby-schemas/jruby-instance? @borrow-instance))
+          (finally
+            (jruby-core/return-to-pool
+             @borrow-instance
+             :borrow-during-pool-init-test
+             []))))))))
 
 (deftest borrow-while-no-instances-available-test
   (testing "when all instances are in use, borrow blocks until an instance becomes available"
-    (tk-bootstrap/with-app-with-config
-     app
-     jruby-testutils/default-services
-     {}
-     (let [pool-size 2
-           config (jruby-testutils/jruby-config {:max-active-instances pool-size})
-           pool-manager-service (tk-app/get-service app :PoolManagerService)
-           pool-context (pool-manager-protocol/create-pool pool-manager-service config)]
-
+    (let [pool-size 2]
+      (jruby-testutils/with-pool-context
+       pool-context
+       jruby-testutils/default-services
+       (jruby-testutils/jruby-config {:max-active-instances pool-size})
        ;; borrow both instances from the pool
        (let [drained-instances (jruby-testutils/drain-pool pool-context pool-size)]
-         (is (= 2 (count drained-instances)))
+         (try
+           (is (= 2 (count drained-instances)))
 
-         ;; attempt a borrow, which will block because no instances are free
-         (let [borrow-instance (future (jruby-core/borrow-from-pool-with-timeout
-                                        pool-context
-                                        :borrow-with-no-free-instances-test
-                                        []))]
-           (is (not (realized? borrow-instance)))
+           ;; attempt a borrow, which will block because no instances are free
+           (let [borrow-instance (future (jruby-core/borrow-from-pool-with-timeout
+                                          pool-context
+                                          :borrow-with-no-free-instances-test
+                                          []))]
+             (is (not (realized? borrow-instance)))
 
-           ;; return an instance to the pool
-           (jruby-core/return-to-pool
-            (first drained-instances)
-            :borrow-with-no-free-instances-test
-            [])
+             ;; return an instance to the pool
+             (jruby-core/return-to-pool
+              (first drained-instances)
+              :borrow-with-no-free-instances-test
+              [])
 
-           ;; now the borrow can complete
-           (is (some? @borrow-instance))))))))
+             ;; now the borrow can complete
+             (is (some? @borrow-instance)))
+           (finally
+             (jruby-testutils/fill-drained-pool drained-instances))))))))
 
 (deftest prime-pools-failure
   (let [pool-size 2
@@ -237,11 +237,10 @@
           (jruby-core/borrow-from-pool-with-timeout pool-context :test []))))))
 
 (deftest test-default-pool-size
-  (logutils/with-test-logging
-    (let [config (jruby-testutils/jruby-config)
-          pool (jruby-pool-manager-core/create-pool-context config)
-          pool-state (jruby-core/get-pool-state pool)]
-      (is (= (jruby-core/default-pool-size (ks/num-cpus)) (:size pool-state))))))
+  (let [config (jruby-testutils/jruby-config)
+        pool (jruby-pool-manager-core/create-pool-context config)
+        pool-state (jruby-core/get-pool-state pool)]
+    (is (= (jruby-core/default-pool-size (ks/num-cpus)) (:size pool-state)))))
 
 (defn jruby-test-config
   ([max-borrows]
@@ -252,74 +251,66 @@
 
 (deftest flush-jruby-after-max-borrows
   (testing "JRubyInstance is not flushed if it has not exceeded max borrows"
-    (tk-bootstrap/with-app-with-config
-     app
+    (jruby-testutils/with-pool-context
+     pool-context
      jruby-testutils/default-services
-     {}
-     (let [config (jruby-test-config 2)
-           pool-manager-service (tk-app/get-service app :PoolManagerService)
-           pool-context (pool-manager-protocol/create-pool pool-manager-service config)
-           instance (jruby-core/borrow-from-pool pool-context :test [])
+     (jruby-test-config 2)
+     (let [instance (jruby-core/borrow-from-pool pool-context :test [])
            id (:id instance)]
        (jruby-core/return-to-pool instance :test [])
        (let [instance (jruby-core/borrow-from-pool pool-context :test [])]
-         (is (= id (:id instance)))))))
+         (is (= id (:id instance)))
+         (jruby-core/return-to-pool instance :test [])))))
   (testing "JRubyInstance is flushed after exceeding max borrows"
-    (tk-bootstrap/with-app-with-config
-     app
+    (jruby-testutils/with-pool-context
+     pool-context
      jruby-testutils/default-services
-     {}
-     (let [config (jruby-test-config 2)
-           pool-manager-service (tk-app/get-service app :PoolManagerService)
-           pool-context (pool-manager-protocol/create-pool pool-manager-service config)]
-       (jruby-testutils/wait-for-jrubies-from-pool-context pool-context)
-       (is (= 1 (count (jruby-core/registered-instances pool-context))))
-       (let [instance (jruby-core/borrow-from-pool pool-context :test [])
-             id (:id instance)]
-         (jruby-core/return-to-pool instance :test [])
-         (jruby-core/borrow-from-pool pool-context :test [])
-         (jruby-core/return-to-pool instance :test [])
-         (let [instance (jruby-core/borrow-from-pool pool-context :test [])]
-           (is (not= id (:id instance)))
-           (jruby-core/return-to-pool instance :test []))
-         (testing "instance is removed from registered elements after flushing"
-           (is (= 1 (count (jruby-core/registered-instances pool-context))))))
-       (testing "Can lock pool after a flush via max borrows"
-         (let [timeout 1
-               new-pool-context (assoc-in pool-context [:config :borrow-timeout] timeout)
-               pool (jruby-internal/get-pool new-pool-context)]
-           (.lock pool)
-           (is (nil? @(future (jruby-core/borrow-from-pool-with-timeout
-                               new-pool-context
-                               :test
-                               []))))
-           (.unlock pool)
-           (is (not (nil? @(future (jruby-core/borrow-from-pool-with-timeout
-                                    new-pool-context
-                                    :test
-                                    []))))))))))
+     (jruby-test-config 2)
+     (jruby-testutils/wait-for-jrubies-from-pool-context pool-context)
+     (is (= 1 (count (jruby-core/registered-instances pool-context))))
+     (let [instance (jruby-core/borrow-from-pool pool-context :test [])
+           id (:id instance)]
+       (jruby-core/return-to-pool instance :test [])
+       (jruby-core/borrow-from-pool pool-context :test [])
+       (jruby-core/return-to-pool instance :test [])
+       (let [instance (jruby-core/borrow-from-pool pool-context :test [])]
+         (is (not= id (:id instance)))
+         (jruby-core/return-to-pool instance :test []))
+       (testing "instance is removed from registered elements after flushing"
+         (is (= 1 (count (jruby-core/registered-instances pool-context))))))
+     (testing "Can lock pool after a flush via max borrows"
+       (let [timeout 1
+             new-pool-context (assoc-in pool-context [:config :borrow-timeout] timeout)
+             pool (jruby-internal/get-pool new-pool-context)]
+         (.lock pool)
+         (is (nil? @(future (jruby-core/borrow-from-pool-with-timeout
+                             new-pool-context
+                             :test
+                             []))))
+         (.unlock pool)
+         (let [instance @(future (jruby-core/borrow-from-pool-with-timeout
+                                  new-pool-context
+                                  :test
+                                  []))]
+           (is (not (nil? instance)))
+           (jruby-core/return-to-pool instance :test []))))))
   (testing "JRubyInstance is not flushed if max borrows setting is set to 0"
-    (tk-bootstrap/with-app-with-config
-     app
+    (jruby-testutils/with-pool-context
+     pool-context
      jruby-testutils/default-services
-     {}
-     (let [config (jruby-test-config 0)
-           pool-manager-service (tk-app/get-service app :PoolManagerService)
-           pool-context (pool-manager-protocol/create-pool pool-manager-service config)
-           instance (jruby-core/borrow-from-pool pool-context :test [])
+     (jruby-test-config 0)
+     (let [instance (jruby-core/borrow-from-pool pool-context :test [])
            id (:id instance)]
        (jruby-core/return-to-pool instance :test [])
        (let [instance (jruby-core/borrow-from-pool pool-context :test [])]
-         (is (= id (:id instance)))))))
+         (is (= id (:id instance)))
+         (jruby-core/return-to-pool instance :test [])))))
   (testing "Can flush a JRubyInstance that is not the first one in the pool"
-    (tk-bootstrap/with-app-with-config
-     app
+    (jruby-testutils/with-pool-context
+     pool-context
      jruby-testutils/default-services
-     {}
-     (let [config (jruby-test-config 2 3)
-           pool-manager-service (tk-app/get-service app :PoolManagerService)
-           pool-context (pool-manager-protocol/create-pool pool-manager-service config)
-           instance1 (jruby-core/borrow-from-pool pool-context :test [])
+     (jruby-test-config 2 3)
+     (let [instance1 (jruby-core/borrow-from-pool pool-context :test [])
            instance2 (jruby-core/borrow-from-pool pool-context :test [])
            id (:id instance2)]
        (jruby-core/return-to-pool instance2 :test [])
@@ -340,14 +331,11 @@
     ; data that gets manipulated during a return that poison pills don't have,
     ; and we'd get null pointer exceptions if this code path tried to access
     ; those non-existent properties on the pill object
-    (tk-bootstrap/with-app-with-config
-     app
+    (jruby-testutils/with-pool-context
+     pool-context
      jruby-testutils/default-services
-     {}
-     (let [config (jruby-test-config 2)
-           pool-manager-service (tk-app/get-service app :PoolManagerService)
-           pool-context (pool-manager-protocol/create-pool pool-manager-service config)
-           pool (jruby-core/get-pool pool-context)
+     (jruby-test-config 2)
+     (let [pool (jruby-core/get-pool pool-context)
            pill (ShutdownPoisonPill. pool)]
        ; Returning a pill should be a noop
        (jruby-core/return-to-pool pill :test [])))))

--- a/test/unit/puppetlabs/services/jruby_pool_manager/jruby_schemas_test.clj
+++ b/test/unit/puppetlabs/services/jruby_pool_manager/jruby_schemas_test.clj
@@ -1,0 +1,16 @@
+(ns puppetlabs.services.jruby-pool-manager.jruby-schemas-test
+  (:require [clojure.test :refer :all]
+            [clojure.string :as str]
+            [dynapath.util :as dynapath]
+            [puppetlabs.services.jruby-pool-manager.jruby-schemas :as jruby-schemas]))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Tests
+
+(deftest using-jruby-9k?-test
+  (testing "using-jruby-9k? returns proper value for loaded jruby"
+    (let [jruby-9k-jar-in-classpath? (or (some #(str/includes? (.getPath %)
+                                                               "jruby-core-9.")
+                                               (dynapath/all-classpath-urls))
+                                         false)]
+      (is (= jruby-9k-jar-in-classpath? jruby-schemas/using-jruby-9k?)))))


### PR DESCRIPTION
This PR adds support for exercising JRuby 9k in jruby-utils.  The default
jruby-utils dependencies still pull in dependencies from JRuby 1.7.x.  When
an alternate leiningen profile, jruby9k, is exercised when `lein test` is run,
however, jruby9k-related dependencies are pulled in instead of JRuby
1.7.x-related ones.

This PR also includes some code specific to how jruby-utils is exercised
when running with JRuby 9k, including:

* Emit a warning if the `compat-version` setting is set.  JRuby 9k has a
   hardcoded `compat-version` set internally and, so, it cannot be
   overridden at run-time.

* Code for cleaning up temporary jars and jar files which are currently
   being leaked by JRuby when a ScriptingContainer is terminated.  See
   SERVER-1777 for more details on pursuing a longer-term fix for this
   issue in JRuby itself.