### PR TITLE
(SERVER-1630) Use lein instead of lein2 for Travis script

### DIFF
--- a/ext/travisci/test.sh
+++ b/ext/travisci/test.sh
@@ -1,9 +1,12 @@
 #!/bin/bash
 
+set -x
 set -e
 
+lein version
+
 echo "Running tests with default JRuby (1.7-based)"
-lein2 test
+lein -U test
 
 echo "Running tests with JRuby 9k"
-lein2 with-profile +jruby9k test
+lein -U with-profile +jruby9k test


### PR DESCRIPTION
This commit changes the use of lein2 to lein in the Travis script.  This
is being done to make the job usable for both Jenkins and Travis CI
runs.