### PR TITLE
(MAINT) Remove warning for jar deletion failure

### DIFF
--- a/src/java/com/puppetlabs/jruby_utils/jruby/InternalScriptingContainer.java
+++ b/src/java/com/puppetlabs/jruby_utils/jruby/InternalScriptingContainer.java
@@ -114,11 +114,7 @@ public class InternalScriptingContainer
         // created for the class loader since that is more likely intended to be
         // persistent.
         if (urlPath.startsWith(classLoaderTempDir)) {
-            File urlPathAsFile = new File(urlPath);
-            if (!urlPathAsFile.delete()) {
-                LOGGER.warn("Unable to delete jar on container termination: {}",
-                        urlPathAsFile);
-            }
+            new File(urlPath).delete();
         }
     }
 


### PR DESCRIPTION
Previously, a warning would be generated each time the JRuby
InternalScriptingContainer would fail to remove a file during its
termination.  Per work in the upstream JRuby project that we hope
will land soon, https://github.com/jruby/jruby/pull/4578, a JRuby
shutdown hook could remove some of these files before the
InternalScriptingContainer has a chance to remove them.  This commit
removes the warnings to avoid creating unnecessary noise in the logs
related to the timing of file deletions.