### PR TITLE
(SERVER-1661) Bump JRuby to 1.7.27 and remove compat-version configurability

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -21,7 +21,7 @@
                  [prismatic/schema]
                  [slingshot]
 
-                 [puppetlabs/jruby-deps "1.7.26-2"]
+                 [puppetlabs/jruby-deps "1.7.27-1"]
 
                  [puppetlabs/i18n]
                  [puppetlabs/kitchensink]

--- a/src/clj/puppetlabs/services/jruby_pool_manager/impl/jruby_internal.clj
+++ b/src/clj/puppetlabs/services/jruby_pool_manager/impl/jruby_internal.clj
@@ -16,7 +16,7 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Private
 
-(def default-jruby-compat-version
+(def default-jruby-1-7-compat-version
   "Default value for JRuby's 'CompatVersion' setting.  This value is only
   meaningful for JRuby 1.7.  For JRuby 9k, this will return `nil` because
   JRuby 9k effectively doesn't support configurable language compatibility
@@ -52,7 +52,7 @@
     (doto jruby
       (.setLoadPaths ruby-load-path)
       (.setCompileMode (get-compile-mode compile-mode)))
-    (when-let [compat-version default-jruby-compat-version]
+    (when-let [compat-version default-jruby-1-7-compat-version]
       (.setCompatVersion jruby compat-version))
     (initialize-scripting-container-fn jruby config)))
 

--- a/src/clj/puppetlabs/services/jruby_pool_manager/impl/jruby_internal.clj
+++ b/src/clj/puppetlabs/services/jruby_pool_manager/impl/jruby_internal.clj
@@ -16,6 +16,13 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Private
 
+(def default-jruby-compat-version
+  "Default value for JRuby's 'CompatVersion' setting.  This value is only
+  meaningful for JRuby 1.7.  For JRuby 9k, this will return `nil` because
+  JRuby 9k effectively doesn't support configurable language compatibility
+  versions."
+  (when-not jruby-schemas/using-jruby-9k? CompatVersion/RUBY1_9))
+
 (schema/defn ^:always-validate initialize-gem-path :- {schema/Keyword schema/Any}
   [{:keys [gem-path gem-home] :as jruby-config} :- {schema/Keyword schema/Any}]
   (if gem-path
@@ -35,26 +42,17 @@
     :force RubyInstanceConfig$CompileMode/FORCE
     :off RubyInstanceConfig$CompileMode/OFF))
 
-(schema/defn ^:always-validate get-compat-version
-  "Get the JRuby compatibility version to use for all ruby components, e.g. the
-  master service and CLI tools."
-  [compat-version :- jruby-schemas/SupportedJRubyCompatVersions]
-  (case compat-version
-    "1.9" (CompatVersion/RUBY1_9)
-    "2.0" (CompatVersion/RUBY2_0)
-    nil))
-
 (schema/defn ^:always-validate init-jruby :- jruby-schemas/ConfigurableJRuby
   "Applies configuration to a JRuby... thing.  See comments in `ConfigurableJRuby`
   schema for more details."
   [jruby :- jruby-schemas/ConfigurableJRuby
    config :- jruby-schemas/JRubyConfig]
-  (let [{:keys [ruby-load-path compile-mode lifecycle compat-version]} config
+  (let [{:keys [ruby-load-path compile-mode lifecycle]} config
         initialize-scripting-container-fn (:initialize-scripting-container lifecycle)]
     (doto jruby
       (.setLoadPaths ruby-load-path)
       (.setCompileMode (get-compile-mode compile-mode)))
-    (when-let [compat-version (get-compat-version compat-version)]
+    (when-let [compat-version default-jruby-compat-version]
       (.setCompatVersion jruby compat-version))
     (initialize-scripting-container-fn jruby config)))
 

--- a/src/clj/puppetlabs/services/jruby_pool_manager/jruby_core.clj
+++ b/src/clj/puppetlabs/services/jruby_pool_manager/jruby_core.clj
@@ -365,4 +365,4 @@
               "getVersionString"
               (into-array [CompatVersion]))
              nil
-             (into-array [jruby-internal/default-jruby-compat-version]))))
+             (into-array [jruby-internal/default-jruby-1-7-compat-version]))))

--- a/src/clj/puppetlabs/services/jruby_pool_manager/jruby_core.clj
+++ b/src/clj/puppetlabs/services/jruby_pool_manager/jruby_core.clj
@@ -346,3 +346,23 @@
        ~@body
        (finally
          (unlock-pool pool# ~reason event-callbacks#)))))
+
+(def jruby-version-info
+  "Default version info string for jruby"
+  ;; For JRuby 9k, the only available getVersionString method takes no parameter
+  ;; whereas for JRuby 1.7.x the only available getVersionString method takes
+  ;; a CompatVersion as a parameter.  Use reflection to invoke the appropriate
+  ;; method.
+  (if jruby-schemas/using-jruby-9k?
+    (.invoke (.getDeclaredMethod
+              OutputStrings
+              "getVersionString"
+              nil)
+             nil
+             nil)
+    (.invoke (.getDeclaredMethod
+              OutputStrings
+              "getVersionString"
+              (into-array [CompatVersion]))
+             nil
+             (into-array [jruby-internal/default-jruby-compat-version]))))

--- a/src/clj/puppetlabs/services/jruby_pool_manager/jruby_schemas.clj
+++ b/src/clj/puppetlabs/services/jruby_pool_manager/jruby_schemas.clj
@@ -38,15 +38,6 @@
   (let [jruby-version Constants/VERSION]
     (= "9." (subs jruby-version 0 2))))
 
-(def supported-jruby-compat-versions
-  (if using-jruby-9k?
-    #{Constants/RUBY_VERSION}
-    #{"1.9" "2.0"}))
-
-(def SupportedJRubyCompatVersions
-  "Schema defining the supported compatibility versions for the JRuby CompatVersions setting"
-  (apply schema/enum supported-jruby-compat-versions))
-
 (def LifecycleFns
   {:initialize-pool-instance IFn
    :cleanup IFn
@@ -76,7 +67,6 @@
    :gem-home schema/Str
    :gem-path (schema/maybe schema/Str)
    :compile-mode SupportedJRubyCompileModes
-   :compat-version SupportedJRubyCompatVersions
    :borrow-timeout schema/Int
    :flush-timeout schema/Int
    :max-active-instances schema/Int

--- a/test/integration/puppetlabs/services/jruby_pool_manager/jruby_internal_test.clj
+++ b/test/integration/puppetlabs/services/jruby_pool_manager/jruby_internal_test.clj
@@ -39,7 +39,8 @@
       (try
         (is (= RubyInstanceConfig$CompileMode/JIT
             (.getCompileMode container)))
-        (if jruby-schemas/using-jruby-9k?
-          (is (.is1_9 (.getCompatVersion container))))
+        (when-not jruby-schemas/using-jruby-9k?
+          (is (= CompatVersion/RUBY1_9 (.getCompatVersion container))
+              "Unexpected default compat version configured for JRuby 1.7 container"))
         (finally
           (.terminate container))))))

--- a/test/integration/puppetlabs/services/jruby_pool_manager/jruby_internal_test.clj
+++ b/test/integration/puppetlabs/services/jruby_pool_manager/jruby_internal_test.clj
@@ -28,35 +28,18 @@
     (is (thrown? ExceptionInfo
                  (jruby-internal/get-compile-mode :foo)))))
 
-(deftest ^:integration settings-plumbed-into-jruby-container
+(deftest settings-plumbed-into-jruby-container
   (testing "settings plumbed into jruby container"
     (let [pool (JRubyPool. 1)
           config (logutils/with-test-logging
                   (jruby-testutils/jruby-config
-                   {:compile-mode :jit
-                    :compat-version 2.0}))
+                   {:compile-mode :jit}))
           instance (jruby-internal/create-pool-instance! pool 0 config #())
           container (:scripting-container instance)]
       (try
         (is (= RubyInstanceConfig$CompileMode/JIT
             (.getCompileMode container)))
-        (is (.is2_0 (.getCompatVersion container)))
+        (if jruby-schemas/using-jruby-9k?
+          (is (.is1_9 (.getCompatVersion container))))
         (finally
           (.terminate container))))))
-
-(deftest get-compat-version-test
-  (testing "returns correct compat version for SupportedJrubyCompatVersions enum"
-    (when (contains? jruby-schemas/supported-jruby-compat-versions "1.9")
-      (is (= CompatVersion/RUBY1_9 (jruby-internal/get-compat-version "1.9"))))
-    (when (contains? jruby-schemas/supported-jruby-compat-versions "2.0")
-      (is (= CompatVersion/RUBY2_0 (jruby-internal/get-compat-version "2.0"))))
-    (when-not (contains? jruby-schemas/supported-jruby-compat-versions
-                         jruby-core/default-jruby-compat-version)
-      (is (nil? (jruby-internal/get-compat-version
-                 jruby-core/default-jruby-compat-version)))))
-  (testing "throws an exception if mode is nil"
-    (is (thrown? ExceptionInfo
-                 (jruby-internal/get-compat-version nil))))
-  (testing "throws an exception for values not in enum"
-    (is (thrown? ExceptionInfo
-                 (jruby-internal/get-compat-version "foo")))))

--- a/test/unit/puppetlabs/services/jruby_pool_manager/jruby_core_test.clj
+++ b/test/unit/puppetlabs/services/jruby_pool_manager/jruby_core_test.clj
@@ -122,3 +122,9 @@
             exit-code (.getStatus return)]
         (is (= 0 exit-code))
         (is (re-find #"bar" out))))))
+
+(deftest jruby-version-info-test
+  (let [pattern (if jruby-schemas/using-jruby-9k?
+                  #"jruby 9."
+                  #"jruby 1.7.")]
+    (is (re-find pattern jruby-core/jruby-version-info))))

--- a/test/unit/puppetlabs/services/jruby_pool_manager/jruby_core_test.clj
+++ b/test/unit/puppetlabs/services/jruby_pool_manager/jruby_core_test.clj
@@ -122,38 +122,3 @@
             exit-code (.getStatus return)]
         (is (= 0 exit-code))
         (is (re-find #"bar" out))))))
-
-(deftest default-jruby-compat-version-test
-  (testing "default jruby compat version is correct for current JRuby"
-    (is (= (if jruby-schemas/using-jruby-9k?
-             Constants/RUBY_VERSION
-             "1.9")
-           jruby-core/default-jruby-compat-version))))
-
-(deftest get-compat-version-for-jruby-config
-  (testing "For get-compat-version-for-jruby-config"
-    (testing "deprecation warning logged if compat version not configurable"
-      (logutils/with-test-logging
-       (is (= "2.3.1" (jruby-core/get-compat-version-for-jruby-config
-                       "2.3.1" "2.3.1" #{"2.3.1"})))
-       (is (logged? #"Setting compat-version for JRuby 9k is deprecated" :warn))))
-    (testing "when unsupported version specified"
-      (logutils/with-test-logging
-       (testing "supported version returned"
-         (is (= "2.3.1" (jruby-core/get-compat-version-for-jruby-config
-                         "1.9" "2.3.1" #{"2.3.1"}))))
-       (testing "warning is logged"
-         (is (logged?
-              #"compat-version is set to `1.9`, which is not a supported version. Version `2.3.1` will be used instead"
-              :warn)))))
-    (testing "supported version is returned"
-      (is (= "2.0" (jruby-core/get-compat-version-for-jruby-config
-                    "2.0" "1.9" #{"1.9" "2.0"}))))
-    (testing "stringified form of supported version is returned"
-      (is (= "2.0" (jruby-core/get-compat-version-for-jruby-config
-                    2.0 "1.9" #{"1.9" "2.0"}))))
-    (testing "default version returned if no version specified"
-      (is (= "1.9" (jruby-core/get-compat-version-for-jruby-config
-                    nil
-                    "1.9"
-                    #{"1.9" "2.0"}))))))

--- a/test/unit/puppetlabs/services/jruby_pool_manager/jruby_pool_test.clj
+++ b/test/unit/puppetlabs/services/jruby_pool_manager/jruby_pool_test.clj
@@ -29,11 +29,7 @@
   (let [minimal-config {:gem-home "/dev/null"
                         :ruby-load-path ["/dev/null"]}
         config        (initialize-jruby-config-with-logging-suppressed
-                       minimal-config)
-        expected-version-fn (fn [version]
-                              (if (= (count jruby-schemas/supported-jruby-compat-versions) 1)
-                                jruby-core/default-jruby-compat-version
-                                version))]
+                       minimal-config)]
     (testing "max-active-instances is set to default if not specified"
       (is (= (jruby-core/default-pool-size (ks/num-cpus)) (:max-active-instances config))))
     (testing "max-borrows-per-instance is set to 0 if not specified"
@@ -55,41 +51,6 @@
                       (assoc :compile-mode "jit")
                       (initialize-jruby-config-with-logging-suppressed)
                       :compile-mode))))
-    (testing "compat-version is set to default if not specified"
-      (is (= jruby-core/default-jruby-compat-version
-             (:compat-version config))))
-    (testing "compat-version is honored if specified as a string"
-      (is (= (expected-version-fn "1.9")
-             (-> minimal-config
-                 (assoc :compat-version "1.9")
-                 (initialize-jruby-config-with-logging-suppressed)
-                 :compat-version)))
-      (is (= (expected-version-fn "2.0")
-             (-> minimal-config
-                 (assoc :compat-version "2.0")
-                 (initialize-jruby-config-with-logging-suppressed)
-                 :compat-version))))
-    (testing "compat-version is honored if specified as a double"
-      ;; depending on how the setting is laid down in a HOCON file, it seems feasible that it might
-      ;; be a string or a double. We should tolerate either.
-      (is (= (expected-version-fn "1.9")
-             (-> minimal-config
-                 (assoc :compat-version 1.9)
-                 (initialize-jruby-config-with-logging-suppressed)
-                 :compat-version)))
-      (is (= (expected-version-fn "2.0")
-             (-> minimal-config
-                 (assoc :compat-version 2.0)
-                 (initialize-jruby-config-with-logging-suppressed)
-                 :compat-version))))
-    (testing "compat-version is honored if specified as an integer"
-      ;; HOCON might parse doubles as integers in some cases? so we should tolerate it as an integer
-      ;; too
-      (is (= (expected-version-fn "2.0")
-             (-> minimal-config
-                 (assoc :compat-version 2)
-                 (initialize-jruby-config-with-logging-suppressed)
-                 :compat-version))))
     (testing "gem-path is set to nil if not specified"
       (is (nil? (-> minimal-config
                     initialize-jruby-config-with-logging-suppressed


### PR DESCRIPTION
This PR bumps the jruby-deps dependency for 1.7 from 1.7.26-2 to
1.7.27-1.

This PR removes support for the compat-version setting from
jruby-utils.  The compat-version setting was introduced in jruby-utils
version 0.4.0 to allow for JRuby 1.7 to optionally run under Ruby
language version 2.0 instead of the default version, 1.9.  JRuby
1.7.27 effectively breaks the ability to use Ruby language version
2.0, however, due to a regression - see:
https://github.com/jruby/jruby/issues/4613 - and is unlikely to be
fixed in the future.  JRuby 9k also does not support compat-version
configurability.  Now that jruby-utils can be used with
JRuby 9k for Ruby language 2+ support, it is no longer valuable to be
able to set compat-version to 2 for use with JRuby 1.7. 

This PR also adds a helper method, jruby-version-info, for getting a
basic version info string from the underlying JRuby library.