### PR TITLE
(SERVER-1821) Bump JRuby 9k dep to 9.1.9.0-2 for ffi memory leak fix

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -46,7 +46,7 @@
                               "-Xms1G"
                               "-Xmx2G"]}
              :testutils {:source-paths ^:replace ["test/unit" "test/integration"]}
-             :jruby9k {:dependencies [[puppetlabs/jruby-deps "9.1.9.0-1"]]}}
+             :jruby9k {:dependencies [[puppetlabs/jruby-deps "9.1.9.0-2"]]}}
 
   :plugins [[lein-parent "0.3.1"]
             [puppetlabs/i18n "0.7.1"]])


### PR DESCRIPTION
This commit bumps the jruby-deps for 9k from 9.1.9.0-1 to 9.1.9.0-2.
This transitively pins to newer versions of jffi and jnr-ffi, 1.2.16 and
2.1.6, which have a fix for leaks around native memory allocations.  See
https://github.com/jnr/jnr-ffi/issues/117.