### PR TITLE
(SERVER-1840) Bump to JRuby 9.1.11.0-1

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -46,7 +46,7 @@
                               "-Xms1G"
                               "-Xmx2G"]}
              :testutils {:source-paths ^:replace ["test/unit" "test/integration"]}
-             :jruby9k {:dependencies [[puppetlabs/jruby-deps "9.1.9.0-2"]]}}
+             :jruby9k {:dependencies [[puppetlabs/jruby-deps "9.1.11.0-1"]]}}
 
   :plugins [[lein-parent "0.3.1"]
             [puppetlabs/i18n "0.7.1"]])


### PR DESCRIPTION
This commit bumps jruby-utils' JRuby 9k test dependency to jruby-deps
9.1.11.0-1.