### PR TITLE
(SERVER-1874) Update to jruby 9.1.15.0

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -46,7 +46,7 @@
                               "-Xms1G"
                               "-Xmx2G"]}
              :testutils {:source-paths ^:replace ["test/unit" "test/integration"]}
-             :jruby9k {:dependencies [[puppetlabs/jruby-deps "9.1.11.0-1"]]}}
+             :jruby9k {:dependencies [[puppetlabs/jruby-deps "9.1.15.0-2"]]}}
 
   :plugins [[lein-parent "0.3.1"]
             [puppetlabs/i18n "0.7.1"]])

--- a/test/unit/puppetlabs/services/jruby_pool_manager/jruby_core_test.clj
+++ b/test/unit/puppetlabs/services/jruby_pool_manager/jruby_core_test.clj
@@ -87,21 +87,21 @@
         (is (re-find #"\bjson\b" out))))
     (testing "irb"
       (let [m (capture-out
-                (with-stdin-str "puts %{HELLO}"
+                (with-stdin-str "puts %{HELLO}\n"
                   (jruby-core/cli-run! min-config "irb" ["-f"])))
             {:keys [return out]} m
             exit-code (.getStatus return)]
         (is (= 0 exit-code))
         (is (re-find #"\nHELLO\n" out)))
       (let [m (capture-out
-                (with-stdin-str "Kernel.exit(42)"
+                (with-stdin-str "Kernel.exit(42)\n"
                   (jruby-core/cli-run! min-config "irb" ["-f"])))
             {:keys [return _]} m
             exit-code (.getStatus return)]
         (is (= 42 exit-code))))
     (testing "irb with -r foo"
       (let [m (capture-out
-                (with-stdin-str "puts %{#{foo}}"
+                (with-stdin-str "puts %{#{foo}}\n"
                   (jruby-core/cli-run! min-config "irb" ["-r" "foo" "-f"])))
             {:keys [return out]} m
             exit-code (.getStatus return)]


### PR DESCRIPTION
This commit updates the jruby version for the jruby9k profile to
9.1.15.0, which is the latest as of now. jruby 9.1.15.0 has a
jruby-readline change which has impacted how we pass strings to IRB in
tests. They now require a newline in order to be executed as expected.