### PR TITLE
(SERVER-1780) Insert hashCode into profiler file name

### DIFF
--- a/src/clj/puppetlabs/services/jruby_pool_manager/impl/jruby_internal.clj
+++ b/src/clj/puppetlabs/services/jruby_pool_manager/impl/jruby_internal.clj
@@ -62,7 +62,7 @@
    profiling-mode :- schema/Keyword]
   (when (and profiler-output-file (not= :off profiling-mode))
     (let [current-time-string (time-format/unparse (time-format/formatters :basic-date-time-no-ms) (time-core/now))
-          real-profiler-output-file (io/as-file (str profiler-output-file "-" current-time-string))]
+          real-profiler-output-file (io/as-file (str profiler-output-file "-" (.hashCode jruby) "-" current-time-string))]
       (doto jruby
         (.setProfileOutput (ProfileOutput. ^File real-profiler-output-file))
         (.setProfilingMode (get-profiling-mode profiling-mode)))


### PR DESCRIPTION
Previously when profiler-output-file was set, it would be the same for
each jruby in the pool, which is undesireable. This commit adds hashCode
to the filename to ensure that they are unique across jrubies.