### PR TITLE
(SERVER-2060) Splay JRuby instance flushing

### DIFF
--- a/src/clj/puppetlabs/services/jruby_pool_manager/impl/jruby_agents.clj
+++ b/src/clj/puppetlabs/services/jruby_pool_manager/impl/jruby_agents.clj
@@ -48,7 +48,8 @@
 (schema/defn ^:always-validate
   prime-pool!
   "Sequentially fill the pool with new JRubyInstances.  NOTE: this
-  function should never be called except by the modify-instance-agent."
+  function should never be called except by the modify-instance-agent
+  to create a pool's initial jruby instances."
   [{:keys [config] :as pool-context} :- jruby-schemas/PoolContext]
   (let [pool (jruby-internal/get-pool pool-context)]
     (log/debug
@@ -62,7 +63,8 @@
             (log/debugf (i18n/trs "Priming JRubyInstance {0} of {1}"
                                   id count))
             (jruby-internal/create-pool-instance! pool id config
-                                                  (partial send-flush-instance! pool-context))
+                                                  (partial send-flush-instance! pool-context)
+                                                  (:splay-instance-flush config))
             (log/infof (i18n/trs "Finished creating JRubyInstance {0} of {1}"
                                  id count)))))
       (catch Exception e
@@ -154,7 +156,8 @@
         (jruby-internal/cleanup-pool-instance! old-instance cleanup-fn)
         (when refill?
           (jruby-internal/create-pool-instance! pool new-id config
-                                                (partial send-flush-instance! pool-context))
+                                                (partial send-flush-instance! pool-context)
+                                                (:splay-instance-flush config))
           (log/infof (i18n/trs "Finished creating JRubyInstance {0} of {1}"
                                new-id pool-size)))
         (catch Exception e

--- a/src/clj/puppetlabs/services/jruby_pool_manager/impl/jruby_internal.clj
+++ b/src/clj/puppetlabs/services/jruby_pool_manager/impl/jruby_internal.clj
@@ -155,7 +155,11 @@
   (when initial-jruby?
     (let [which-step (inc (mod id total-instances))
           step-size (quot total-borrows total-instances)]
-      ;; If total-instances is larger than total-borrows then step-size will be 0
+      ;; If total-instances is larger than total-borrows then step-size will
+      ;; be 0. For example, if a user has configured their pool with 4 JRuby
+      ;; instances but a max-requests-per-instance of 1. Users shouldn't need
+      ;; splaying if they are never re-using JRuby instances, or if they are
+      ;; re-using them fewer times than the number of JRubies in the pool.
       (when-not (= 0 step-size)
         (* step-size which-step)))))
 

--- a/src/clj/puppetlabs/services/jruby_pool_manager/impl/jruby_internal.clj
+++ b/src/clj/puppetlabs/services/jruby_pool_manager/impl/jruby_internal.clj
@@ -153,8 +153,7 @@
     (let [which-step (inc (mod id total-instances))
           step-size (quot total-borrows total-instances)]
       ;; If total-instances is larger than total-borrows then step-size will be 0
-      (if (= 0 step-size)
-        nil
+      (when-not (= 0 step-size)
         (* step-size which-step)))))
 
 (schema/defn ^:always-validate

--- a/src/clj/puppetlabs/services/jruby_pool_manager/impl/jruby_internal.clj
+++ b/src/clj/puppetlabs/services/jruby_pool_manager/impl/jruby_internal.clj
@@ -145,6 +145,9 @@
 
 (schema/defn ^:always-validate
   initial-borrows-value :- (schema/maybe schema/Int)
+  "Determines how many borrows before instance of given id should be flushed
+  in order to best splay it. Returns nil if not applicable (either not
+  `initial-jruby?` or there are more instances than max-borrows)."
   [id :- schema/Int
    total-instances :- schema/Int
    total-borrows :- schema/Int

--- a/src/clj/puppetlabs/services/jruby_pool_manager/jruby_core.clj
+++ b/src/clj/puppetlabs/services/jruby_pool_manager/jruby_core.clj
@@ -168,6 +168,7 @@
       (update-in [:flush-timeout] #(or % default-flush-timeout))
       (update-in [:max-active-instances] #(or % (default-pool-size (ks/num-cpus))))
       (update-in [:max-borrows-per-instance] #(or % 0))
+      (update-in [:splay-instance-flush] #(if (nil? %) true %))
       (update-in [:environment-vars] #(or % {}))
       (update-in [:lifecycle] initialize-lifecycle-fns)
       jruby-internal/initialize-gem-path))

--- a/src/clj/puppetlabs/services/jruby_pool_manager/jruby_schemas.clj
+++ b/src/clj/puppetlabs/services/jruby_pool_manager/jruby_schemas.clj
@@ -65,6 +65,8 @@
     * :max-active-instances - The maximum number of JRubyInstances that
         will be pooled.
 
+    * :splay-instance-flush - Whether or not to splay flushing of instances
+
     * :environment-vars - A map of environment variables and their values to be
         passed through to the JRuby scripting container and visible to any Ruby code.
 
@@ -83,6 +85,7 @@
    :flush-timeout schema/Int
    :max-active-instances schema/Int
    :max-borrows-per-instance schema/Int
+   :splay-instance-flush schema/Bool
    :lifecycle LifecycleFns
    :environment-vars {schema/Keyword schema/Str}
    :profiling-mode SupportedJRubyProfilingModes
@@ -129,6 +132,7 @@
 (def JRubyPuppetInstanceInternal
   {:flush-instance-fn IFn
    :pool pool-queue-type
+   :initial-borrows (schema/maybe schema/Int)
    :max-borrows schema/Int
    :state JRubyInstanceStateContainer})
 

--- a/test/integration/puppetlabs/services/jruby_pool_manager/jruby_pool_int_test.clj
+++ b/test/integration/puppetlabs/services/jruby_pool_manager/jruby_pool_int_test.clj
@@ -196,6 +196,7 @@
      jruby-testutils/default-services
      (jruby-testutils/jruby-config {:max-active-instances 4
                                     :max-borrows-per-instance 10
+                                    :splay-instance-flush false
                                     :borrow-timeout
                                     test-borrow-timeout})
      (let [pool (jruby-core/get-pool pool-context)]

--- a/test/unit/puppetlabs/services/jruby_pool_manager/jruby_pool_test.clj
+++ b/test/unit/puppetlabs/services/jruby_pool_manager/jruby_pool_test.clj
@@ -220,53 +220,50 @@
    (jruby-testutils/jruby-config {:max-active-instances max-instances
                                   :max-borrows-per-instance max-borrows})))
 
-(defn drain-and-refill
-  [pool-context
-   instance-count]
-  (let [instances (jruby-testutils/drain-pool pool-context 2)
-        ids (into #{} (map :id instances))]
-    (jruby-testutils/fill-drained-pool instances)
-    ids))
-
-
 (deftest splay-jruby-instance-flushing
   (testing "Disabled JRuby instance splaying -"
     (jruby-testutils/with-pool-context
       pool-context
       jruby-testutils/default-services
-      (jruby-testutils/jruby-config {:max-active-instances 4
-                                     :max-borrows-per-instance 4
+      (jruby-testutils/jruby-config {:max-active-instances 5
+                                     :max-borrows-per-instance 3
                                      :splay-instance-flush false})
-      (let [first-ids (drain-and-refill pool-context 4)
-            second-ids (drain-and-refill pool-context 4)
-            third-ids (drain-and-refill pool-context 4)
-            ;; All jruby instances should be recylced after this return
+      (let [first-ids (jruby-testutils/drain-and-refill pool-context)
+            second-ids (jruby-testutils/drain-and-refill pool-context)
+            ;; All jruby instances should be recycled after this refill
             ;; but the ids will be of old instances that were drained
-            fourth-ids (drain-and-refill pool-context 4)]
+            third-ids (jruby-testutils/drain-and-refill pool-context)]
         (testing "Does not flush any instances prior to max borrows"
-          (is (= first-ids second-ids third-ids fourth-ids)))
-        (let [fifth-ids (drain-and-refill pool-context 4)]
+          (is (= first-ids second-ids third-ids)))
+        (let [fourth-ids (jruby-testutils/drain-and-refill pool-context)]
           (testing "All instances flushed after max borrows"
-            (is (empty? (set/intersection fifth-ids fourth-ids))))))))
+            (is (empty? (set/intersection fourth-ids third-ids))))))))
   (testing "Splayed JRuby instance flushing -"
     (jruby-testutils/with-pool-context
      pool-context
      jruby-testutils/default-services
-      ;; with two instances, each with two max borrows, we should recycle
-      ;; an instance every cycle of draining
-     (jruby-test-config 2 2)
-     (let [first-ids (drain-and-refill pool-context 2)
-           second-ids (drain-and-refill pool-context 2)
-           old-instance-set (set/intersection first-ids second-ids)
-           new-instance-set (set/difference second-ids first-ids)]
-       (testing "Instances first flush is splayed"
-         (is (= 1 (count old-instance-set))))
-       (let [third-ids (drain-and-refill pool-context 2)]
-         (testing "Instances are not repeatedly flushed at splay interval"
-           (is (= 1 (count (set/intersection third-ids new-instance-set)))))
-         (let [fourth-ids (drain-and-refill pool-context 2)]
-           (testing "Instances are flushed at max-borrow after initial splay"
-             (is (empty? (set/intersection fourth-ids new-instance-set))))))))))
+      ;; with three instances, each with three max borrows, we should recycle
+      ;; an instance every cycle of draining. The first instance to be
+      ;; recycled will do so after the first drain, its replacement should
+      ;; then stay until the fourth drain/refill.
+     (jruby-test-config 3 3)
+     (let [first-ids (jruby-testutils/drain-and-refill pool-context)
+           second-ids (jruby-testutils/drain-and-refill pool-context)
+           third-ids (jruby-testutils/drain-and-refill pool-context)
+           fourth-ids (jruby-testutils/drain-and-refill pool-context)
+           fifth-ids (jruby-testutils/drain-and-refill pool-context)
+           original-instances-surviving-first-drain (set/intersection first-ids second-ids)
+           new-instance-after-first-drain (set/difference second-ids first-ids)
+           original-instances-surviving-second-drain (set/intersection first-ids third-ids)
+           original-instances-surviving-third-drain (set/intersection first-ids fourth-ids)]
+       (testing "Initial instances are flushed each splay interval"
+         (is (= 2 (count original-instances-surviving-first-drain)))
+         (is (= 1 (count original-instances-surviving-second-drain)))
+         (is (= 0 (count original-instances-surviving-third-drain))))
+       (testing "New instances are flushed at max-borrows"
+         (is (seq (set/intersection new-instance-after-first-drain third-ids)))
+         (is (seq (set/intersection new-instance-after-first-drain fourth-ids)))
+         (is (empty? (set/intersection new-instance-after-first-drain fifth-ids))))))))
 
 (deftest flush-jruby-after-max-borrows
   (testing "JRubyInstance is not flushed if it has not exceeded max borrows"

--- a/test/unit/puppetlabs/services/jruby_pool_manager/jruby_pool_test.clj
+++ b/test/unit/puppetlabs/services/jruby_pool_manager/jruby_pool_test.clj
@@ -261,8 +261,8 @@
          (is (= 1 (count original-instances-surviving-second-drain)))
          (is (= 0 (count original-instances-surviving-third-drain))))
        (testing "New instances are flushed at max-borrows"
-         (is (seq (set/intersection new-instance-after-first-drain third-ids)))
-         (is (seq (set/intersection new-instance-after-first-drain fourth-ids)))
+         (is (not-empty (set/intersection new-instance-after-first-drain third-ids)))
+         (is (not-empty (set/intersection new-instance-after-first-drain fourth-ids)))
          (is (empty? (set/intersection new-instance-after-first-drain fifth-ids))))))))
 
 (deftest flush-jruby-after-max-borrows


### PR DESCRIPTION
Previously all JRuby instances would be flushed after they reached
`max-requests-per-instance`. This could cause a thundering herd of
JRuby instance initialization which we've observed during
performance testing.

This patch creates a `splay-instance-flush` configuration option
(available via code for testing but not intended to be plumbed through
to the user). If this is true (the default value) when we first
initialize a JRuby Pool and fill it with instances each instance
receives an `initial-borrows` value that is a fraction of the
max-requests. If set, the `return-to-pool` method will prefer the
value of initial-borrows to that of max-requests to determine if
the instance should be flushed. Subsequent instance creations wil not
receive an initial-borrows value unless the entire pool is being
flushed and refilled.