### PR TITLE
(SERVER-2130) Update default compile-mode to jit for jruby9k

### DIFF
--- a/src/clj/puppetlabs/services/jruby_pool_manager/jruby_core.clj
+++ b/src/clj/puppetlabs/services/jruby_pool_manager/jruby_core.clj
@@ -22,8 +22,11 @@
 ;;; Constants
 
 (def default-jruby-compile-mode
-  "Default value for JRuby's 'CompileMode' setting."
-  :off)
+  "Default value for JRuby's 'CompileMode' setting. For 1.7 we default to off,
+  but for 9k we turn jit on by default."
+  (if jruby-schemas/using-jruby-9k?
+    :jit
+    :off))
 
 (def default-borrow-timeout
   "Default timeout when borrowing instances from the JRuby pool in

--- a/test/integration/puppetlabs/services/jruby_pool_manager/jruby_internal_test.clj
+++ b/test/integration/puppetlabs/services/jruby_pool_manager/jruby_internal_test.clj
@@ -61,3 +61,19 @@
                                 profiler-files)]
         (is (= 2 (count profiler-files)))
         (is (not-empty (slurp real-profiler-file)))))))
+
+(deftest default-compile-mode
+  (testing "default compile-mode changes based on jruby version"
+    (let [pool (JRubyPool. 1)
+          config (logutils/with-test-logging
+                  (jruby-testutils/jruby-config {}))
+          instance (jruby-internal/create-pool-instance! pool 0 config #())
+          container (:scripting-container instance)]
+      (try
+        (if jruby-schemas/using-jruby-9k?
+          (is (= RubyInstanceConfig$CompileMode/JIT
+                 (.getCompileMode container)))
+          (is (= RubyInstanceConfig$CompileMode/OFF
+                 (.getCompileMode container))))
+        (finally
+          (.terminate container))))))

--- a/test/integration/puppetlabs/services/jruby_pool_manager/jruby_internal_test.clj
+++ b/test/integration/puppetlabs/services/jruby_pool_manager/jruby_internal_test.clj
@@ -3,7 +3,6 @@
             [puppetlabs.services.jruby-pool-manager.impl.jruby-internal :as jruby-internal]
             [puppetlabs.services.jruby-pool-manager.jruby-testutils :as jruby-testutils]
             [puppetlabs.services.jruby-pool-manager.jruby-schemas :as jruby-schemas]
-            [puppetlabs.services.jruby-pool-manager.jruby-core :as jruby-core]
             [puppetlabs.trapperkeeper.testutils.logging :as logutils]
             [puppetlabs.kitchensink.core :as ks]
             [me.raynes.fs :as fs])

--- a/test/unit/puppetlabs/services/jruby_pool_manager/jruby_core_test.clj
+++ b/test/unit/puppetlabs/services/jruby_pool_manager/jruby_core_test.clj
@@ -4,8 +4,7 @@
             [puppetlabs.services.jruby-pool-manager.jruby-core :as jruby-core]
             [puppetlabs.trapperkeeper.testutils.logging :as logutils]
             [puppetlabs.services.jruby-pool-manager.jruby-schemas :as jruby-schemas])
-  (:import (java.io ByteArrayOutputStream PrintStream ByteArrayInputStream)
-           (org.jruby.runtime Constants)))
+  (:import (java.io ByteArrayOutputStream PrintStream ByteArrayInputStream)))
 
 (use-fixtures :once schema-test/validate-schemas)
 


### PR DESCRIPTION
In jruby 9k, to get comparable performance to 1.7, jit must be enabled
for compile-mode. This commit updates the default compile mode for jruby
to be jit when the version is 9k, but maintains the old default of off
for jruby 1.7.