### PR TITLE
(SERVER-2193) Add API for retrieving JRuby thread dumps

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -15,6 +15,7 @@
   :test-paths ["test/unit" "test/integration"]
 
   :dependencies [[org.clojure/clojure]
+                 [org.clojure/java.jmx]
                  [org.clojure/tools.logging]
 
                  [me.raynes/fs]

--- a/src/clj/puppetlabs/services/jruby_pool_manager/jruby_core.clj
+++ b/src/clj/puppetlabs/services/jruby_pool_manager/jruby_core.clj
@@ -181,6 +181,16 @@
   (swap! (get-in pool-context [:internal :event-callbacks]) conj callback-fn))
 
 (schema/defn ^:always-validate
+  get-jruby-thread-dump
+  "Get thread dumps from JRuby instances in the pool."
+  [pool-context :- jruby-schemas/PoolContext]
+  (reduce (fn [result instance]
+            (assoc result (:id instance)
+                          (jruby-internal/get-instance-thread-dump instance)))
+          {}
+          (registered-instances pool-context)))
+
+(schema/defn ^:always-validate
   borrow-from-pool :- jruby-schemas/JRubyInstanceOrPill
   "Borrows a JRuby interpreter from the pool. If there are no instances
   left in the pool then this function will block until there is one available."


### PR DESCRIPTION
This commit adds a `get-jruby-thread-dump` method that iterates through
the interpreters registered to a JRuby pool and returns a Ruby backtrace
from each one. Generation of the backtraces is done via the JRuby JMX
management interface and thus requires `-Djruby.management.enabled=true`
to be set in JAVA_ARGS.