### PR TITLE
(maint) Remove redundant formatting from logging

### DIFF
--- a/src/clj/puppetlabs/services/jruby_pool_manager/impl/jruby_agents.clj
+++ b/src/clj/puppetlabs/services/jruby_pool_manager/impl/jruby_agents.clj
@@ -60,12 +60,12 @@
       (let [count (.remainingCapacity pool)]
         (dotimes [i count]
           (let [id (inc i)]
-            (log/debugf (i18n/trs "Priming JRubyInstance {0} of {1}"
+            (log/debug (i18n/trs "Priming JRubyInstance {0} of {1}"
                                   id count))
             (jruby-internal/create-pool-instance! pool id config
                                                   (partial send-flush-instance! pool-context)
                                                   (:splay-instance-flush config))
-            (log/infof (i18n/trs "Finished creating JRubyInstance {0} of {1}"
+            (log/info (i18n/trs "Finished creating JRubyInstance {0} of {1}"
                                  id count)))))
       (catch Exception e
         (.clear pool)
@@ -158,7 +158,7 @@
           (jruby-internal/create-pool-instance! pool new-id config
                                                 (partial send-flush-instance! pool-context)
                                                 (:splay-instance-flush config))
-          (log/infof (i18n/trs "Finished creating JRubyInstance {0} of {1}"
+          (log/info (i18n/trs "Finished creating JRubyInstance {0} of {1}"
                                new-id pool-size)))
         (catch Exception e
           (.clear pool)

--- a/src/clj/puppetlabs/services/jruby_pool_manager/impl/jruby_internal.clj
+++ b/src/clj/puppetlabs/services/jruby_pool_manager/impl/jruby_internal.clj
@@ -151,7 +151,7 @@
     (.unregister pool instance)
     (cleanup-fn instance)
     (.terminate scripting-container)
-    (log/infof (i18n/trs "Cleaned up old JRubyInstance with id {0}."
+    (log/info (i18n/trs "Cleaned up old JRubyInstance with id {0}."
                          (:id instance)))))
 
 (schema/defn ^:always-validate
@@ -197,7 +197,7 @@
       (when-not ruby-load-path
         (throw (Exception.
                  (i18n/trs "JRuby service missing config value 'ruby-load-path'"))))
-      (log/infof (i18n/trs "Creating JRubyInstance with id {0}." id))
+      (log/info (i18n/trs "Creating JRubyInstance with id {0}." id))
       (let [scripting-container (create-scripting-container
                                   config)]
         (let [instance (jruby-schemas/map->JRubyInstance
@@ -318,7 +318,7 @@
       (if (and (pos? borrow-limit)
                (>= (:borrow-count new-state) borrow-limit))
         (do
-          (log/infof
+          (log/info
            (i18n/trs "Flushing JRubyInstance {0} because it has exceeded its borrow limit of ({1})"
                      (:id instance)
                      borrow-limit))

--- a/src/clj/puppetlabs/services/jruby_pool_manager/jruby_core.clj
+++ b/src/clj/puppetlabs/services/jruby_pool_manager/jruby_core.clj
@@ -291,7 +291,7 @@
     (if url
       (cli-ruby! config
         (concat ["-e" (format "load '%s'" url) "--"] args))
-      (log/errorf (i18n/trs "command {0} could not be found in {1}"
+      (log/error (i18n/trs "command {0} could not be found in {1}"
                             command bin-dir)))))
 
 (defmacro with-jruby-instance


### PR DESCRIPTION
This commit swaps formatting log methods such as `log/infof` for their
unformatted counterparts: `log/info`. This is done in cases where the
log method is receiving a value generated by `i18n`. The `i18n` methods
perform formatting, which renders the additional formatting done by
`log` redundant and potentially dangerous as any translation that
generates a sequence of characters that looks like a format statement
will cause an exception to be raised.