### PR TITLE
Experiment with "reference pool"

### DIFF
--- a/dev-resources/logback-test.xml
+++ b/dev-resources/logback-test.xml
@@ -7,7 +7,7 @@
 
     <!--<logger name="log4j.logger.org.eclipse.jetty.server" level="warn"/>-->
 
-    <root level="warn">
+    <root level="info">
         <appender-ref ref="STDOUT" />
     </root>
 </configuration>

--- a/src/clj/puppetlabs/services/jruby_pool_manager/impl/jruby_agents.clj
+++ b/src/clj/puppetlabs/services/jruby_pool_manager/impl/jruby_agents.clj
@@ -17,7 +17,7 @@
   next-instance-id :- schema/Int
   [id :- schema/Int
    pool-context :- jruby-schemas/PoolContext]
-  (let [pool-size (jruby-internal/get-pool-size pool-context)
+  (let [pool-size (jruby-internal/get-instance-count pool-context)
         next-id (+ id pool-size)]
     (if (> next-id Integer/MAX_VALUE)
       (mod next-id pool-size)
@@ -147,8 +147,8 @@
    old-instances :- [JRubyInstance]
    refill? :- schema/Bool]
   (let [pool (jruby-internal/get-pool pool-context)
-        pool-size (jruby-internal/get-pool-size pool-context)
-        new-instance-ids (map inc (range pool-size))
+        instance-count (jruby-internal/get-instance-count pool-context)
+        new-instance-ids (map inc (range instance-count))
         config (:config pool-context)
         cleanup-fn (get-in config [:lifecycle :cleanup])]
     (doseq [[old-instance new-id] (zipmap old-instances new-instance-ids)]
@@ -159,7 +159,7 @@
                                                 (partial send-flush-instance! pool-context)
                                                 (:splay-instance-flush config))
           (log/infof (i18n/trs "Finished creating JRubyInstance {0} of {1}"
-                               new-id pool-size)))
+                               new-id instance-count)))
         (catch Exception e
           (.clear pool)
           (jruby-internal/insert-poison-pill pool e)

--- a/src/clj/puppetlabs/services/jruby_pool_manager/impl/jruby_internal.clj
+++ b/src/clj/puppetlabs/services/jruby_pool_manager/impl/jruby_internal.clj
@@ -34,7 +34,7 @@
   "Instantiate a new queue object to use as the pool of free JRuby's."
   [size]
   {:post [(instance? jruby-schemas/pool-queue-type %)]}
-  (JRubyPool. size))
+  (ReferencePool. size))
 
 (defn instantiate-reference-pool
   "Instantiate a new pool object to be used as the JRuby reference pool.

--- a/src/clj/puppetlabs/services/jruby_pool_manager/impl/jruby_internal.clj
+++ b/src/clj/puppetlabs/services/jruby_pool_manager/impl/jruby_internal.clj
@@ -147,7 +147,7 @@
   create-reference-pool-from-config :- jruby-schemas/PoolState
   "Create a new pool of handles to a JRuby instance, based on
   the config input."
-  [{maxBorrows :max-concurrent-thread-count} :- jruby-schemas/JRubyConfig]
+  [{maxBorrows :max-active-instances} :- jruby-schemas/JRubyConfig]
   {:pool (instantiate-reference-pool maxBorrows)
    :size 1})
 

--- a/src/clj/puppetlabs/services/jruby_pool_manager/impl/jruby_internal.clj
+++ b/src/clj/puppetlabs/services/jruby_pool_manager/impl/jruby_internal.clj
@@ -223,7 +223,7 @@
                                      :max-borrows max-borrows-per-instance
                                      :initial-borrows initial-borrows
                                      :flush-instance-fn flush-instance-fn
-                                     :state (atom {:borrow-count 0})}})
+                                     :state (atom {:borrow-count 0 :flush-pending false})}})
               modified-instance (initialize-pool-instance-fn instance)]
           (.register pool modified-instance)
           modified-instance)))))

--- a/src/clj/puppetlabs/services/jruby_pool_manager/impl/jruby_internal.clj
+++ b/src/clj/puppetlabs/services/jruby_pool_manager/impl/jruby_internal.clj
@@ -197,13 +197,13 @@
     id :- schema/Int
     config :- jruby-schemas/JRubyConfig
     flush-instance-fn :- IFn]
-    (create-pool-instance! pool id config flush-instance-fn false))
+   (create-pool-instance! pool id config flush-instance-fn false))
   ([pool :- jruby-schemas/pool-queue-type
     id :- schema/Int
     config :- jruby-schemas/JRubyConfig
     flush-instance-fn :- IFn
     initial-jruby? :- schema/Bool]
-    (let [{:keys [ruby-load-path lifecycle
+   (let [{:keys [ruby-load-path lifecycle
                   max-active-instances max-borrows-per-instance]} config
           initialize-pool-instance-fn (:initialize-pool-instance lifecycle)
           initial-borrows (initial-borrows-value id
@@ -248,9 +248,21 @@
 
 (schema/defn ^:always-validate
   get-pool-size :- schema/Int
-  "Gets the size of the JRuby pool from the pool context."
+  "Gets the number of allowed simultaneous borrows of
+   the JRuby pool from the pool context. For the JRubyPool,
+   this is equivalent to the number of active instances.
+   For the ReferencePool, it is the number of references to
+   the instance that we are allowed to hand out at once."
   [context :- jruby-schemas/PoolContext]
   (get-in context [:config :max-active-instances]))
+
+(schema/defn ^:always-validate
+  get-instance-count :- schema/Int
+  "Gets the number of JRuby instances in the pool. For the
+  JRubyPool, this is equivalent to the number of allowed
+  simultaneous borrows. For the ReferencePool, it is always 1."
+  [context :- jruby-schemas/PoolContext]
+  (:size (get-pool-state context)))
 
 (schema/defn ^:always-validate
   get-flush-timeout :- schema/Int

--- a/src/clj/puppetlabs/services/jruby_pool_manager/impl/jruby_pool_manager_core.clj
+++ b/src/clj/puppetlabs/services/jruby_pool_manager/impl/jruby_pool_manager_core.clj
@@ -9,10 +9,13 @@
   "Creates a new JRuby pool context with an empty pool. Once the JRuby
   pool object has been created, it will need to be filled using `prime-pool!`."
   [config :- jruby-schemas/JRubyConfig]
-  (let [shutdown-on-error-fn (get-in config [:lifecycle :shutdown-on-error])]
+  (let [shutdown-on-error-fn (get-in config [:lifecycle :shutdown-on-error])
+        pool-state (if (:multithreaded config)
+                     (atom (jruby-internal/create-reference-pool-from-config config))
+                     (atom (jruby-internal/create-pool-from-config config)))]
     {:config config
      :internal {:modify-instance-agent (jruby-agents/pool-agent shutdown-on-error-fn)
-                :pool-state (atom (jruby-internal/create-pool-from-config config))
+                :pool-state pool-state
                 :event-callbacks (atom [])}}))
 
 (schema/defn ^:always-validate

--- a/src/clj/puppetlabs/services/jruby_pool_manager/jruby_core.clj
+++ b/src/clj/puppetlabs/services/jruby_pool_manager/jruby_core.clj
@@ -36,12 +36,6 @@
   Current value is 1200000ms, or 20 minutes."
   1200000)
 
-(def default-max-concurrent-threads
-  "Default number of threads that can be run through a JRuby instance
-  when in multithreaded mode. This default value is based on Jetty's
-  minimum size for its thread pool."
-  8)
-
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Functions
 
@@ -179,7 +173,6 @@
       (update-in [:environment-vars] #(or % {}))
       (update-in [:lifecycle] initialize-lifecycle-fns)
       (update-in [:multithreaded] #(if (nil? %) false %))
-      (update-in [:max-concurrent-thread-count] #(or % default-max-concurrent-threads))
       jruby-internal/initialize-gem-path))
 
 (schema/defn register-event-handler

--- a/src/clj/puppetlabs/services/jruby_pool_manager/jruby_core.clj
+++ b/src/clj/puppetlabs/services/jruby_pool_manager/jruby_core.clj
@@ -15,7 +15,6 @@
   (:import (puppetlabs.services.jruby_pool_manager.jruby_schemas JRubyInstance)
            (clojure.lang IFn)
            (java.util.concurrent TimeUnit)
-           (org.jruby CompatVersion)
            (org.jruby.util.cli OutputStrings)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/src/clj/puppetlabs/services/jruby_pool_manager/jruby_core.clj
+++ b/src/clj/puppetlabs/services/jruby_pool_manager/jruby_core.clj
@@ -36,6 +36,12 @@
   Current value is 1200000ms, or 20 minutes."
   1200000)
 
+(def default-max-concurrent-threads
+  "Default number of threads that can be run through a JRuby instance
+  when in multithreaded mode. This default value is based on Jetty's
+  minimum size for its thread pool."
+  8)
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Functions
 
@@ -172,6 +178,8 @@
       (update-in [:splay-instance-flush] #(if (nil? %) true %))
       (update-in [:environment-vars] #(or % {}))
       (update-in [:lifecycle] initialize-lifecycle-fns)
+      (update-in [:multithreaded] #(if (nil? %) false %))
+      (update-in [:max-concurrent-thread-count] #(or % default-max-concurrent-threads))
       jruby-internal/initialize-gem-path))
 
 (schema/defn register-event-handler

--- a/src/clj/puppetlabs/services/jruby_pool_manager/jruby_schemas.clj
+++ b/src/clj/puppetlabs/services/jruby_pool_manager/jruby_schemas.clj
@@ -85,7 +85,9 @@
    :lifecycle LifecycleFns
    :environment-vars {schema/Keyword schema/Str}
    :profiling-mode SupportedJRubyProfilingModes
-   :profiler-output-file schema/Str})
+   :profiler-output-file schema/Str
+   :multithreaded schema/Bool
+   :max-concurrent-thread-count schema/Int})
 
 (def JRubyPoolAgent
   "An agent configured for use in managing JRuby pools"

--- a/src/clj/puppetlabs/services/jruby_pool_manager/jruby_schemas.clj
+++ b/src/clj/puppetlabs/services/jruby_pool_manager/jruby_schemas.clj
@@ -86,8 +86,7 @@
    :environment-vars {schema/Keyword schema/Str}
    :profiling-mode SupportedJRubyProfilingModes
    :profiler-output-file schema/Str
-   :multithreaded schema/Bool
-   :max-concurrent-thread-count schema/Int})
+   :multithreaded schema/Bool})
 
 (def JRubyPoolAgent
   "An agent configured for use in managing JRuby pools"

--- a/src/clj/puppetlabs/services/jruby_pool_manager/jruby_schemas.clj
+++ b/src/clj/puppetlabs/services/jruby_pool_manager/jruby_schemas.clj
@@ -118,7 +118,8 @@
 
 (def JRubyInstanceState
   "State metadata for an individual JRubyInstance"
-  {:borrow-count schema/Int})
+  {:borrow-count schema/Int
+   :flush-pending schema/Bool})
 
 (def JRubyInstanceStateContainer
   "An atom containing the current state of a given JRubyInstance."

--- a/src/java/com/puppetlabs/jruby_utils/pool/LockablePool.java
+++ b/src/java/com/puppetlabs/jruby_utils/pool/LockablePool.java
@@ -107,7 +107,7 @@ public interface LockablePool<E> {
      * have been borrowed but not yet returned to the pool at the time this
      * method is called will remain registered.
      */
-    void clear();
+    void clear() throws InterruptedException;
 
     /**
      * Returns the number of elements that can be added into the pool.  Equal

--- a/src/java/com/puppetlabs/jruby_utils/pool/LockablePool.java
+++ b/src/java/com/puppetlabs/jruby_utils/pool/LockablePool.java
@@ -27,8 +27,11 @@ public interface LockablePool<E> {
      * {@link #getRegisteredElements()}.
      *
      * @param e the element to remove from the list of registered elements
+     * @throws InterruptedException if the calling thread is interrupted while
+     *                              it waits for all instances to be returned
+     *                              to the pool
      */
-    void unregister(E e);
+    void unregister(E e) throws InterruptedException;
 
     /**
      * Borrow an element from the pool.  This method will block until

--- a/src/java/com/puppetlabs/jruby_utils/pool/ReferencePool.java
+++ b/src/java/com/puppetlabs/jruby_utils/pool/ReferencePool.java
@@ -122,6 +122,8 @@ public final class ReferencePool<E> implements LockablePool<E> {
 
             instance = e;
             registeredElements.add(e);
+            // No borrows of the newly registered instance
+            borrowCount.set(0);
 
             signalPoolNotEmpty();
         } finally {
@@ -136,6 +138,8 @@ public final class ReferencePool<E> implements LockablePool<E> {
         try {
             instance = null;
             registeredElements.remove(e);
+            borrowCount.set(0);
+
             signalIfLockCanProceed();
         } finally {
             lock.unlock();
@@ -269,17 +273,18 @@ public final class ReferencePool<E> implements LockablePool<E> {
      * Clears the registered instance. Waits until all held references
      * have been returned, because references to unregistered instances
      * cannot be released.
+     * TODO: DO WE NEED AN IMPLEMENTATION HERE OR IS THERE NO POINT?
      */
     @Override
     public void clear() {
-        final ReentrantLock lock = this.queueLock;
-        lock.lock();
-        try {
-          registeredElements.clear();
-          instance = null;
-        } finally {
-            lock.unlock();
-        }
+//        final ReentrantLock lock = this.queueLock;
+//        lock.lock();
+//        try {
+//          registeredElements.clear();
+//          instance = null;
+//        } finally {
+//            lock.unlock();
+//        }
     }
 
     // How many refs need to be released for the pool to be full again.

--- a/src/java/com/puppetlabs/jruby_utils/pool/ReferencePool.java
+++ b/src/java/com/puppetlabs/jruby_utils/pool/ReferencePool.java
@@ -315,7 +315,11 @@ public final class ReferencePool<E> implements LockablePool<E> {
         final ReentrantLock lock = this.queueLock;
         lock.lock();
         try {
-            size = this.maxBorrowCount - this.borrowCount.get();
+            if (instance == null) {
+                size = 0;
+            } else {
+                size = this.maxBorrowCount - this.borrowCount.get();
+            }
         } finally {
             lock.unlock();
         }

--- a/src/java/com/puppetlabs/jruby_utils/pool/ReferencePool.java
+++ b/src/java/com/puppetlabs/jruby_utils/pool/ReferencePool.java
@@ -1,0 +1,499 @@
+package com.puppetlabs.jruby_utils.pool;
+
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.ReentrantLock;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * An implementation of LockablePool for managing a pool of JRubyInstances.
+ *
+ * @param <E> the type of element that can be added to the pool.
+ */
+public final class ReferencePool<E> implements LockablePool<E> {
+    private static final Logger LOGGER = LoggerFactory.getLogger(
+            ReferencePool.class);
+
+    // The `LockingPool` contract requires some synchronization behaviors that
+    // are not natively present in any of the JDK deque implementations -
+    // specifically to allow one calling thread to call lock() to supercede
+    // and hold off any pending pool borrowers until unlock() is called.
+    // This class implementation fulfills the contract by managing the
+    // synchronization constructs directly rather than deferring to an
+    // underlying JDK data structure to manage concurrent access.
+    //
+    // This implementation is modeled somewhat off of what the
+    // `LinkedBlockingDeque` class in the OpenJDK does to manage
+    // concurrency.  It uses a single `ReentrantLock` to provide mutual
+    // exclusion around offer and take requests, with condition variables
+    // used to park and later reawaken requests as needed, e.g., when pool
+    // items are unavailable for borrowing or when the pool lock is
+    // unavailable.
+    //
+    // See http://hg.openjdk.java.net/jdk8/jdk8/jdk/file/687fd7c7986d/src/share/classes/java/util/concurrent/LinkedBlockingDeque.java#l157
+    //
+    // Because access to the underlying deque is synchronized within
+    // this class, the pool is backed by a non-synchronized JDK `LinkedList`.
+
+    // Lock which guards all accesses to the underlying queue and registered
+    // element set.  Constructed as "nonfair" for performance, like the
+    // lock that a `LinkedBlockingDeque` does.  Not clear that we need this
+    // to be a "fair" lock.
+    private final ReentrantLock queueLock = new ReentrantLock(false);
+
+    // Condition signaled when all elements that have been registered have been
+    // returned to the queue or if a pill has been inserted.  Awaited when a
+    // lock has been requested but one or more registered elements has been
+    // borrowed from the pool.
+    private final Condition lockAvailable = queueLock.newCondition();
+
+    // Condition signaled when an element has been added into the queue.
+    // Awaited when a request has been made to borrow an item but no elements
+    // currently exist in the queue.
+    private final Condition queueNotEmpty = queueLock.newCondition();
+
+    // Condition signaled when the pool has been unlocked.  Awaited when a
+    // request has been made to borrow an item or lock the pool but the pool
+    // is currently locked.
+    private final Condition poolNotLocked = queueLock.newCondition();
+
+    // Holds a reference to all registered elements, which in this case should
+    // only be the single JRuby instance.
+    private final Set<E> registeredElements = new CopyOnWriteArraySet<>();
+
+    // The JRuby instance that this pool hands out references to
+    private E instance;
+
+    // How many times the JRuby instance can be borrowed at once
+    private int maxBorrowCount;
+
+    // Current number of references to the pool held out in the world.
+    // Updates to this need to be visible to all threads.
+    private volatile AtomicInteger borrowCount;
+
+    // Thread which currently holds the pool lock.  null indicates that
+    // there is no current pool lock holder.  Using the current Thread
+    // object for tracking the pool lock owner is comparable to what the JDK's
+    // `ReentrantLock` class does via the `AbstractOwnableSynchronizer` class:
+    //
+    // http://hg.openjdk.java.net/jdk8/jdk8/jdk/file/687fd7c7986d/src/share/classes/java/util/concurrent/locks/ReentrantLock.java#l164
+    // http://hg.openjdk.java.net/jdk8/jdk8/jdk/file/687fd7c7986d/src/share/classes/java/util/concurrent/locks/AbstractOwnableSynchronizer.java#l64
+    //
+    // Unlike the `AbstractOwnableSynchronizer` class implementation, we marked
+    // this variable as `volatile` because we couldn't convince ourselves
+    // that it would be safe to update this variable from different threads and
+    // not be susceptible to per-thread / per-CPU caching causing the wrong
+    // value to be seen by a thread.  `volatile` seems safer and doesn't appear
+    // to impose any noticeable performance degradation.
+    private volatile Thread poolLockThread = null;
+
+    // Holds a poison pill object for errors and shutdowns
+    // If not null, takes priority over any pool instance when a call to
+    // borrowItem is made. Returns made using releaseItem are ignored if the
+    // released item is the poison pill already stored here
+    private volatile E pill;
+
+    /**
+     * Create a "pool" of handles to a Jruby instance.
+     *
+     * @param maxBorrows the max number of instance refs that can be handed out
+     */
+    public ReferencePool(int maxBorrows) {
+        this.instance = null;
+        this.maxBorrowCount = maxBorrows;
+        this.borrowCount = new AtomicInteger(0);
+    }
+
+    @Override
+    public void register(E e) {
+        final ReentrantLock lock = this.queueLock;
+        lock.lock();
+        try {
+            if (instance != null) {
+                throw new IllegalStateException(
+                        "Unable to register additional instance, pool full");
+            }
+
+            instance = e;
+            registeredElements.add(e);
+
+            signalPoolNotEmpty();
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    @Override
+    public void unregister(E e) {
+        final ReentrantLock lock = this.queueLock;
+        lock.lock();
+        try {
+            instance = null;
+            registeredElements.remove(e);
+            signalIfLockCanProceed();
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    @Override
+    public E borrowItem() throws InterruptedException {
+        E item = null;
+        final ReentrantLock lock = this.queueLock;
+        lock.lock();
+        try {
+            final Thread currentThread = Thread.currentThread();
+            do {
+                if (this.pill != null) {
+                    // Return the pill immediately if there is one
+                    item = pill;
+                } else if (isPoolLockHeldByAnotherThread(currentThread)) {
+                    poolNotLocked.await();
+                } else if (this.borrowCount.get() >= this.maxBorrowCount) {
+                    queueNotEmpty.await();
+                } else if (this.instance != null) {
+                    item = this.instance;
+                    this.borrowCount.getAndIncrement();
+                }
+            } while (item == null);
+        } finally {
+            lock.unlock();
+        }
+
+        return item;
+    }
+
+    @Override
+    public E borrowItemWithTimeout(long timeout, TimeUnit unit) throws
+            InterruptedException {
+        E item = null;
+        final ReentrantLock lock = this.queueLock;
+        long remainingMaxTimeToWait = unit.toNanos(timeout);
+
+        // `queueLock.lockInterruptibly()` is called here as opposed to just
+        // `queueLock.queueLock` to follow the pattern that the JDK's
+        // `LinkedBlockingDeque` does for a timed poll from a deque.  See:
+        // http://hg.openjdk.java.net/jdk8/jdk8/jdk/file/687fd7c7986d/src/share/classes/java/util/concurrent/LinkedBlockingDeque.java#l516
+        lock.lockInterruptibly();
+        try {
+            final Thread currentThread = Thread.currentThread();
+            // This pattern of using timed `awaitNanos` on a condition
+            // variable to track the total time spent waiting for an item to
+            // be available to be borrowed follows the logic that the JDK's
+            // `LinkedBlockingDeque` in `pollFirst` uses.  See:
+            // http://hg.openjdk.java.net/jdk8/jdk8/jdk/file/687fd7c7986d/src/share/classes/java/util/concurrent/LinkedBlockingDeque.java#l522
+            do {
+                if (this.pill != null) {
+                    // Return the pill immediately if there is one
+                    item = pill;
+                } else if (isPoolLockHeldByAnotherThread(currentThread)) {
+                    if (remainingMaxTimeToWait <= 0) {
+                        break;
+                    }
+                    remainingMaxTimeToWait =
+                            poolNotLocked.awaitNanos(remainingMaxTimeToWait);
+                } else if (this.borrowCount.get() >= this.maxBorrowCount) {
+                    if (remainingMaxTimeToWait <= 0) {
+                        break;
+                    }
+                    remainingMaxTimeToWait =
+                            queueNotEmpty.awaitNanos(remainingMaxTimeToWait);
+                } else if (instance != null) {
+                    item = instance;
+                    this.borrowCount.getAndIncrement();
+                }
+            } while (item == null);
+        } finally {
+            lock.unlock();
+        }
+
+        return item;
+    }
+
+    /**
+     * Release an item and return it to the pool. Does nothing if the item
+     * being released is the pill.
+     * Throws an `IllegalArgumentException` if the item is not currently
+     * registered by the pool and the item is not the pill, if one has been
+     * inserted
+     */
+    @Override
+    public void releaseItem(E e) {
+        final ReentrantLock lock = this.queueLock;
+        lock.lock();
+        try {
+            if (e != this.pill) {
+                if (!isRegistered(e)) {
+                    String errorMsg = "The item being released is not registered with the pool";
+                    throw new IllegalArgumentException(errorMsg);
+                }
+
+                this.borrowCount.getAndDecrement();
+                signalPoolNotEmpty();
+            }
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    private boolean isRegistered(E e) {
+        return this.registeredElements.contains(e);
+    }
+
+    /**
+     * Insert a poison pill into the pool.  It should only ever be used to
+     * insert a `PoisonPill` or `ShutdownPoisonPill` to the pool. Only the
+     * first call will insert a pill. Subsequent insertions will be ignored
+     */
+    @Override
+    public void insertPill(E e) {
+        final ReentrantLock lock = this.queueLock;
+        lock.lock();
+        try {
+            if (this.pill == null) {
+                this.pill = e;
+                signalPoolNotEmpty();
+            }
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * Clears the registered instance. Waits until all held references
+     * have been returned, because references to unregistered instances
+     * cannot be released.
+     */
+    @Override
+    public void clear() {
+        final ReentrantLock lock = this.queueLock;
+        lock.lock();
+        try {
+          registeredElements.clear();
+          instance = null;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    // How many refs need to be released for the pool to be full again.
+    @Override
+    public int remainingCapacity() {
+        return this.borrowCount.get();
+    }
+
+    @Override
+    public int size() {
+        int size;
+        final ReentrantLock lock = this.queueLock;
+        lock.lock();
+        try {
+            size = this.maxBorrowCount - this.borrowCount.get();
+        } finally {
+            lock.unlock();
+        }
+        return size;
+    }
+
+    /**
+     * Lock the pool. Blocks until the lock is granted and the pool has been filled
+     * back up to its full capacity
+     * @throws InterruptedException
+     */
+    @Override
+    public void lock() throws InterruptedException {
+        final ReentrantLock lock = this.queueLock;
+        lock.lock();
+        try {
+            String pillErrorMsg = "Lock can't be granted because a pill has been inserted";
+
+            final Thread currentThread = Thread.currentThread();
+            while (!isPoolLockHeldByCurrentThread(currentThread)) {
+                if (this.pill != null) {
+                    throw new InterruptedException(pillErrorMsg);
+                }
+                if (!isPoolLockHeld()) {
+                    poolLockThread = currentThread;
+                } else {
+                    poolNotLocked.await();
+                }
+            }
+            try {
+                // Wait until all references have been returned to the pool
+                while (this.borrowCount.get() > 0) {
+                    lockAvailable.await();
+                    if (this.pill != null) {
+                        throw new InterruptedException(pillErrorMsg);
+                    }
+                }
+            } catch (Exception e) {
+                freePoolLock();
+                throw e;
+            }
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    @Override
+    public void lockWithTimeout(long timeout, TimeUnit unit) throws InterruptedException, TimeoutException {
+        final ReentrantLock lock = this.queueLock;
+        long remainingMaxTimeToWait = unit.toNanos(timeout);
+
+        // `queueLock.lockInterruptibly()` is called here as opposed to just
+        // `queueLock.queueLock` to follow the pattern that the JDK's
+        // `LinkedBlockingDeque` does for a timed poll from a deque.  See:
+        // http://hg.openjdk.java.net/jdk8/jdk8/jdk/file/687fd7c7986d/src/share/classes/java/util/concurrent/LinkedBlockingDeque.java#l516
+        lock.lockInterruptibly();
+        try {
+            String pillErrorMsg = "Lock can't be granted because a pill has been inserted";
+            String timeoutErrorMsg = "Timeout limit reached before lock could be granted";
+
+            final Thread currentThread = Thread.currentThread();
+            while (!isPoolLockHeldByCurrentThread(currentThread)) {
+                if (this.pill != null) {
+                    throw new InterruptedException(pillErrorMsg);
+                }
+
+                if (!isPoolLockHeld()) {
+                    poolLockThread = currentThread;
+                } else {
+                    if (remainingMaxTimeToWait <= 0) {
+                        throw new TimeoutException(timeoutErrorMsg);
+                    }
+                    remainingMaxTimeToWait = poolNotLocked.awaitNanos(remainingMaxTimeToWait);
+                }
+            }
+
+            try {
+                // Wait until all references have been returned to the pool
+                while (this.borrowCount.get() > 0) {
+                    if (remainingMaxTimeToWait <= 0) {
+                        throw new TimeoutException(timeoutErrorMsg);
+                    }
+                    remainingMaxTimeToWait = lockAvailable.awaitNanos(remainingMaxTimeToWait);
+
+                    if (this.pill != null) {
+                        throw new InterruptedException(pillErrorMsg);
+                    }
+                }
+            } catch (Exception e) {
+                freePoolLock();
+                throw e;
+            }
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    @Override
+    public boolean isLocked() {
+        boolean locked;
+        final ReentrantLock lock = this.queueLock;
+        lock.lock();
+        try {
+            locked = isPoolLockHeld();
+        } finally {
+            lock.unlock();
+        }
+        return locked;
+    }
+
+    @Override
+    public void unlock() {
+        final ReentrantLock lock = this.queueLock;
+        lock.lock();
+        try {
+            final Thread currentThread = Thread.currentThread();
+            if (!isPoolLockHeldByCurrentThread(currentThread)) {
+                String lockErrorMessage;
+                if (isPoolLockHeldByAnotherThread(currentThread)) {
+                    lockErrorMessage = "held by " + poolLockThread;
+                } else {
+                    lockErrorMessage = "not held by any thread";
+                }
+                throw new IllegalStateException(
+                        "Unlock requested from thread not holding the lock.  " +
+                        "Requested from " +
+                        currentThread +
+                        " but lock " +
+                        lockErrorMessage +
+                        ".");
+            }
+            freePoolLock();
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    public Set<E> getRegisteredElements() {
+      return registeredElements;
+    }
+
+    private void freePoolLock() {
+        poolLockThread = null;
+        // Need to use 'signalAll' here because there might be multiple
+        // waiters (e.g., multiple borrowers) queued up, waiting for the
+        // pool to be unlocked.
+        poolNotLocked.signalAll();
+        // Borrowers that are woken up when an instance is returned to the
+        // pool and the pool queueLock is held would then start waiting on a
+        // 'poolNotLocked' signal instead.  Re-signalling 'queueNotEmpty' here
+        // allows any borrowers still waiting on the 'queueNotEmpty' signal to be
+        // reawoken when the pool lock is released, compensating for any
+        // 'queueNotEmpty' signals that might have been essentially ignored from
+        // when the pool lock was held.
+        if (this.borrowCount.get() < this.maxBorrowCount) {
+            queueNotEmpty.signalAll();
+        }
+    }
+
+    /**
+     * Should be called if the pool is no longer empty (or a pill is inserted),
+     * so that threads waiting for pool instances can be woken up
+     */
+    private void signalPoolNotEmpty() {
+        // Could use 'signalAll' here instead of 'signal' but 'signal' is
+        // less expensive in that only one waiter will be woken up.  Can use
+        // signal here because the thread being awoken will be able to borrow
+        // a pool instance and any further waiters will be woken up by
+        // subsequent posts of this signal when instances are added/returned to
+        // the queue.
+        queueNotEmpty.signal();
+        signalIfLockCanProceed();
+    }
+
+    /**
+     * Checks if threads waiting on the pool lock should be woken up.
+     * This will wake them up if either the number of available instances is
+     * equal to the maximum size of the pool, or if a pill has been inserted
+     */
+    private void signalIfLockCanProceed() {
+        // Could use 'signalAll' here instead of 'signal'.  Doesn't really
+        // matter though in that there will only be one waiter at most which
+        // is active at a time - a caller of lock() that has just acquired
+        // the pool lock but is waiting for the live queue to be completely
+        // filled
+        if (instance != null || pill != null) {
+            lockAvailable.signal();
+        }
+    }
+
+    private boolean isPoolLockHeld() {
+        return poolLockThread != null;
+    }
+
+    private boolean isPoolLockHeldByCurrentThread(Thread currentThread) {
+        return poolLockThread == currentThread;
+    }
+
+    private boolean isPoolLockHeldByAnotherThread(Thread currentThread) {
+        return (poolLockThread != null) && (poolLockThread != currentThread);
+    }
+}

--- a/test/unit/puppetlabs/jruby_utils/lockable_ref_pool_test.clj
+++ b/test/unit/puppetlabs/jruby_utils/lockable_ref_pool_test.clj
@@ -1,0 +1,657 @@
+(ns puppetlabs.jruby_utils.lockable-ref-pool-test
+  (:require [clojure.test :refer :all]
+            [puppetlabs.services.jruby-pool-manager.jruby-testutils :as jruby-testutils])
+  (:import (com.puppetlabs.jruby_utils.pool ReferencePool)
+           (java.util.concurrent TimeUnit ExecutionException TimeoutException)))
+
+(defn timed-deref
+  [ref]
+  (deref ref 10000 :timed-out))
+
+(defn create-empty-pool
+  ([] (create-empty-pool 10))
+  ([maxBorrows]
+    (ReferencePool. maxBorrows)))
+
+(defn create-populated-pool
+  ([] create-populated-pool 10)
+  ([size]
+  (let [pool (create-empty-pool size)]
+      (.register pool (str "foo"))
+    pool)))
+
+(defn borrow-n-instances
+  [pool n]
+  (doall (for [_ (range n)]
+           (.borrowItem pool))))
+
+(defn return-instances
+  [pool instances]
+  (doseq [instance instances]
+    (.releaseItem pool instance)))
+
+(deftest pool-register-above-maximum-throws-exception-test
+  (testing "attempt to register new instance with pool at max capacity fails"
+    (let [pool (create-empty-pool)]
+      (.register pool "foo ok")
+      (is (thrown? IllegalStateException
+                   (.register pool "foo bar"))))))
+
+(deftest pool-unregister-from-pool-test
+  (testing "registered elements properly removed for"
+    (let [pool (create-populated-pool 3)
+          instances (borrow-n-instances pool 2)]
+      (testing "first unregister call should delete the instance"
+        (let [first-instance (first instances)
+              _ (.unregister pool first-instance)
+              registered-elements (.getRegisteredElements pool)]
+          (is (= 0 (.size registered-elements)))))
+      (testing "second unregister call should not error"
+        (let [second-instance (second instances)
+              _ (.unregister pool second-instance)
+              registered-elements (.getRegisteredElements pool)]
+          (is (= 0 (.size registered-elements))))))))
+
+(deftest pool-lock-is-blocking-until-borrows-returned-test
+  (let [pool (create-populated-pool 3)
+        instances (borrow-n-instances pool 3)
+        future-started? (promise)
+        lock-acquired? (promise)
+        unlock? (promise)]
+    (is (= 3 (count instances)))
+    (is (not (.isLocked pool)))
+    (let [lock-thread (future (deliver future-started? true)
+                              (.lock pool)
+                              (deliver lock-acquired? true)
+                              @unlock?
+                              (.unlock pool)
+                              true)]
+      @future-started?
+      (testing "pool.lock() blocks until all instances are returned to the pool"
+        (is (not (realized? lock-acquired?)))
+
+        (testing (str "other threads may successfully return instances while "
+                      "pool.lock() is being executed")
+          (.releaseItem pool (first instances))
+          (is (not (realized? lock-acquired?)))
+          (.releaseItem pool (second instances))
+          (is (not (realized? lock-acquired?)))
+          (.releaseItem pool (nth instances 2)))
+
+        (is (true? (timed-deref lock-acquired?))
+            "timed out waiting for the lock to be acquired")
+        (is (not (realized? lock-thread)))
+        (is (.isLocked pool))
+        (deliver unlock? true)
+        (is (true? (timed-deref lock-thread))
+            "timed out waiting for the lock thread to finish")
+        (is (not (.isLocked pool))))
+
+      (testing "borrows may be resumed after unlock()"
+        (let [instance (.borrowItem pool)]
+          (.releaseItem pool instance))
+        ;; make sure we got here
+        (is (true? true))))))
+
+(deftest pool-lock-blocks-borrows-test
+  (testing "no other threads may borrow once pool.lock() has been invoked (before or after it returns)"
+    (let [pool (create-populated-pool 2)
+          instances (borrow-n-instances pool 2)
+          lock-thread-started? (promise)
+          lock-acquired? (promise)
+          unlock? (promise)]
+      (is (= 2 (count instances)))
+      (is (not (.isLocked pool)))
+      (let [lock-thread (future (deliver lock-thread-started? true)
+                                (.lock pool)
+                                (deliver lock-acquired? true)
+                                @unlock?
+                                (.unlock pool)
+                                true)]
+        @lock-thread-started?
+        (is (not (realized? lock-acquired?)))
+        (let [borrow-after-lock-requested-thread-started? (promise)
+              borrow-after-lock-requested-instance-acquired? (promise)
+              borrow-after-lock-requested-thread
+              (future (deliver borrow-after-lock-requested-thread-started? true)
+                      (let [instance (.borrowItem pool)]
+                        (deliver borrow-after-lock-requested-instance-acquired? true)
+                        (.releaseItem pool instance))
+                      true)]
+          @borrow-after-lock-requested-thread-started?
+          (is (not (realized? borrow-after-lock-requested-instance-acquired?)))
+
+          (return-instances pool instances)
+          (is (true? (timed-deref lock-acquired?))
+              "timed out waiting for the lock acquired thread to start")
+          (is (.isLocked pool))
+          (is (not (realized? borrow-after-lock-requested-instance-acquired?)))
+          (is (not (realized? lock-thread)))
+
+          (let [borrow-after-lock-acquired-thread-started? (promise)
+                borrow-after-lock-acquired-instance-acquired? (promise)
+                borrow-after-lock-acquired-thread
+                (future (deliver borrow-after-lock-acquired-thread-started?
+                                 true)
+                        (let [instance (.borrowItem pool)]
+                          (deliver borrow-after-lock-acquired-instance-acquired? true)
+                          (.releaseItem pool instance))
+                        true)]
+            @borrow-after-lock-acquired-thread-started?
+            (is (not (realized? borrow-after-lock-acquired-instance-acquired?)))
+
+            (deliver unlock? true)
+
+            (is (true? (timed-deref lock-thread))
+                "timed out waiting for the lock thread to finish")
+            (is (true? (timed-deref
+                        borrow-after-lock-requested-instance-acquired?))
+                (str "timed out waiting for the borrow after lock requested "
+                     "to be completed"))
+            (is (true? (timed-deref
+                        borrow-after-lock-requested-thread))
+                (str "timed out waiting for the borrow after lock requested "
+                     "thread to finish"))
+            (is (true? (timed-deref
+                        borrow-after-lock-acquired-instance-acquired?))
+                "timed out waiting for the borrow after lock acquired")
+            (is (true? (timed-deref
+                        borrow-after-lock-acquired-thread))
+                (str "timed out waiting for the borrow after lock acquired "
+                     "thread to finish")))))
+            (is (not (.isLocked pool))))))
+
+(deftest pool-lock-supersedes-existing-borrows-test
+  (testing "if there are pending borrows when pool.lock() is called, they aren't fulfilled until after unlock()"
+    (let [pool (create-populated-pool 2)
+          instances (borrow-n-instances pool 2)
+          blocked-borrow-thread-started? (promise)
+          blocked-borrow-thread-borrowed? (promise)
+          blocked-borrow-thread (future (deliver blocked-borrow-thread-started? true)
+                                        (let [instance (.borrowItem pool)]
+                                          (deliver blocked-borrow-thread-borrowed? true)
+                                          (.releaseItem pool instance))
+                                        true)
+          lock-thread-started? (promise)
+          lock-acquired? (promise)
+          unlock? (promise)
+          lock-thread (future (deliver lock-thread-started? true)
+                              (.lock pool)
+                              (deliver lock-acquired? true)
+                              @unlock?
+                              (.unlock pool)
+                              true)]
+      @blocked-borrow-thread-started?
+      @lock-thread-started?
+      (is (not (realized? blocked-borrow-thread-borrowed?)))
+      (let [start (System/currentTimeMillis)]
+        (while (and (not (.isLocked pool))
+                    (< (- (System/currentTimeMillis) start) 10000))
+          (Thread/yield)))
+      (is (.isLocked pool))
+      (is (not (realized? lock-acquired?)))
+
+      (return-instances pool instances)
+      (is (not (realized? blocked-borrow-thread-borrowed?)))
+      (is (not (realized? lock-thread)))
+      (is (true? (timed-deref lock-acquired?))
+          "timed out waiting for the lock to be acquired")
+      (is (.isLocked pool))
+
+      (deliver unlock? true)
+      (is (true? (timed-deref lock-thread))
+          "timed out waiting for the lock thread to finish")
+      (is (true? (timed-deref blocked-borrow-thread-borrowed?))
+          "timed out waiting for the borrow to complete")
+      (is (true? (timed-deref blocked-borrow-thread))
+          "timed out waiting for the borrow thread to complete")
+      (is (not (.isLocked pool))))))
+
+(deftest pool-lock-reentrant-for-borrow-from-locking-thread
+  (testing "the thread that holds the pool lock may borrow instances while holding the lock"
+    (let [pool (create-populated-pool 2)]
+      (is (not (.isLocked pool)))
+      (.lock pool)
+      (is (.isLocked pool))
+      (let [instance (.borrowItem pool)]
+        (is (true? true))
+        (.releaseItem pool instance))
+      (is (true? true))
+      (.unlock pool)
+      (is (not (.isLocked pool))))))
+
+(deftest pool-lock-reentrant-with-many-borrows-test
+  (testing "the thread that holds the pool lock may borrow instances while holding the lock, even with other borrows queued"
+    (let [pool (create-populated-pool 2)]
+      (is (not (.isLocked pool)))
+      (.lock pool)
+      (is (.isLocked pool))
+      (let [borrow-thread-started-1? (promise)
+            borrow-thread-started-2? (promise)
+            borrow-thread-borrowed-1? (promise)
+            borrow-thread-borrowed-2? (promise)
+            borrow-thread-1 (future (deliver borrow-thread-started-1? true)
+                                    (let [instance (.borrowItem pool)]
+                                      (deliver borrow-thread-borrowed-1? true)
+                                      (.releaseItem pool instance))
+                                    true)
+            borrow-thread-2 (future (deliver borrow-thread-started-2? true)
+                                    (let [instance (.borrowItem pool)]
+                                      (deliver borrow-thread-borrowed-2? true)
+                                      (.releaseItem pool instance))
+                                    true)]
+        @borrow-thread-started-1?
+        @borrow-thread-started-2?
+        (is (not (realized? borrow-thread-borrowed-1?)))
+        (is (not (realized? borrow-thread-borrowed-2?)))
+
+        (let [instance (.borrowItem pool)]
+          (is (true? true))
+          (.releaseItem pool instance))
+
+        (is (true? true))
+        (.unlock pool)
+        (is (true? (timed-deref borrow-thread-1))
+            "timed out waiting for first borrow thread to finish")
+        (is (true? (timed-deref borrow-thread-2))
+            "timed out waiting for second borrow thread to finish"))
+        (is (not (.isLocked pool))))))
+
+(deftest pool-lock-reentrant-for-many-locks-test
+  (testing "multiple threads cannot lock the pool while it is already locked"
+    (let [pool (create-populated-pool 1)]
+      (is (not (.isLocked pool)))
+      (.lock pool)
+      (is (.isLocked pool))
+      (let [lock-thread-started-1? (promise)
+            lock-thread-started-2? (promise)
+            lock-thread-locked-1? (promise)
+            lock-thread-locked-2? (promise)
+            lock-thread-1 (future (deliver lock-thread-started-1? true)
+                                  (.lock pool)
+                                  (deliver lock-thread-locked-1? true)
+                                  (.unlock pool)
+                                  true)
+            lock-thread-2 (future (deliver lock-thread-started-2? true)
+                                  (.lock pool)
+                                  (deliver lock-thread-locked-2? true)
+                                  (.unlock pool)
+                                  true)]
+        @lock-thread-started-1?
+        @lock-thread-started-2?
+        (is (not (realized? lock-thread-locked-1?)))
+        (is (not (realized? lock-thread-locked-2?)))
+        (.unlock pool)
+        (is (true? (timed-deref lock-thread-1))
+            "timed out waiting for first lock thread to finish")
+        (is (true? (timed-deref lock-thread-2))
+            "timed out waiting for second lock thread to finish"))
+        (is (not (.isLocked pool))))))
+
+(deftest pool-lock-not-held-after-thread-interrupt
+  (let [pool (create-populated-pool 1)
+        item (.borrowItem pool)
+        lock-thread-obj (promise)
+        lock-thread-locked? (promise)
+        lock-thread (future (deliver lock-thread-obj (Thread/currentThread))
+                            (.lock pool)
+                            (deliver lock-thread-locked? true))]
+    (testing (str "write locker's thread can be interrupted while waiting for "
+                  "instances to be returned")
+      (.interrupt @lock-thread-obj)
+      (is (thrown? ExecutionException (timed-deref lock-thread)))
+      (is (not (realized? lock-thread-locked?))))
+      (is (not (.isLocked pool)))
+
+    (.releaseItem pool item)
+    (testing "new write lock can be taken after prior write lock interrupted"
+      (.lock pool)
+      (is (.isLocked pool)))))
+
+(deftest pool-unlock-from-thread-not-holding-lock-fails
+  (testing "call to unlock pool when no lock held throws exception"
+    (let [pool (create-populated-pool 1)]
+      (is (thrown? IllegalStateException (.unlock pool)))))
+  (testing "call to unlock pool from thread not holding lock throws exception"
+    (let [pool (create-populated-pool 1)
+          lock-started? (promise)
+          unlock? (promise)
+          lock-thread (future (.lock pool)
+                              (deliver lock-started? true)
+                              @unlock?
+                              (.unlock pool)
+                              true)]
+      @lock-started?
+      (is (.isLocked pool))
+      (is (thrown? IllegalStateException (.unlock pool)))
+      (deliver unlock? true)
+      (is (true? (timed-deref lock-thread))
+          "timed out waiting for lock thread to finish")
+      (is (not (.isLocked pool))))))
+
+(deftest pool-lock-with-timeout-test
+  (testing "lock is granted if timeout is not exceeded"
+    (let [pool (create-populated-pool 1)]
+      (.lockWithTimeout pool 1 TimeUnit/NANOSECONDS)
+      (is (.isLocked pool))))
+  (testing "lock throws TimeoutException if timeout is exceeded"
+    (let [pool (create-populated-pool 1)
+          borrowed-instance (.borrowItem pool)]
+      (is (thrown-with-msg?
+           TimeoutException
+           #"Timeout limit reached before lock could be granted"
+           (.lockWithTimeout pool 1 TimeUnit/NANOSECONDS)
+           (is (not (.isLocked pool))))))))
+
+(deftest pool-release-item-test
+  (testing "releaseItem returns item to pool and allows pool to still be lockable"
+    (let [pool (create-populated-pool 2)
+          instance (.borrowItem pool)]
+      (is (= 1 (.size pool)))
+      (.releaseItem pool instance)
+      (is (= 2 (.size pool)))
+      (is (not (.isLocked pool)))
+      (.lock pool)
+      (is (.isLocked pool))
+      (is (nil? (timed-deref
+                 (future (.borrowItemWithTimeout pool
+                                                 1
+                                                 TimeUnit/MICROSECONDS))))
+          "timed out waiting for borrow with timeout in lock to finish")
+      (.unlock pool)
+      (is (not (nil? (timed-deref
+                      (future (.borrowItemWithTimeout pool
+                                                      1
+                                                      TimeUnit/MICROSECONDS)))))
+          "timed out waiting for borrow with timeout after unlock to finish")
+      (is (not (.isLocked pool))))))
+
+(deftest pool-borrow-blocks-borrow-when-pool-empty
+  (testing "borrow from pool blocks while the pool is empty"
+    (let [pool (create-populated-pool 1)
+          item (.borrowItem pool)
+          borrow-thread-started? (promise)
+          borrow-thread-borrowed? (promise)
+          borrow-thread (future (deliver borrow-thread-started? true)
+                                (let [instance (.borrowItem pool)]
+                                  (deliver borrow-thread-borrowed? true)
+                                  (.releaseItem pool instance))
+                                true)]
+      @borrow-thread-started?
+      (is (not (realized? borrow-thread-borrowed?)))
+      (.releaseItem pool item)
+      (is (true? (timed-deref borrow-thread))
+          "timed out waiting for borrow thread to finish"))))
+
+(deftest pool-timed-borrows-test
+  (testing "pool borrows with timeout"
+    (let [pool (create-populated-pool 1)
+          item (.borrowItem pool)]
+      (testing "borrow times out and returns nil when pool is empty"
+        (is (nil? (timed-deref
+                   (future (.borrowItemWithTimeout pool
+                                                   1
+                                                   TimeUnit/MICROSECONDS))))))
+      (.releaseItem pool item)
+      (testing "borrow succeeds when pool is non-empty"
+        (is (identical? item (timed-deref
+                              (future (.borrowItemWithTimeout
+                                       pool
+                                       1
+                                       TimeUnit/MICROSECONDS)))))))))
+
+(deftest pool-can-do-blocking-borrow-after-borrow-timed-out
+  (testing "can do blocking borrow from pool after previous borrow timed out"
+    (let [pool (create-populated-pool 1)
+          item (.borrowItem pool)]
+      (is (nil? (.borrowItemWithTimeout pool 1 TimeUnit/MICROSECONDS)))
+      (let [borrow-thread-started? (promise)
+            borrow-thread-borrowed? (promise)
+            borrow-thread (future (deliver borrow-thread-started? true)
+                                  (let [instance (.borrowItem pool)]
+                                    (deliver borrow-thread-borrowed? true)
+                                    (.releaseItem pool instance))
+                                  true)]
+        @borrow-thread-started?
+        (is (not (realized? borrow-thread-borrowed?)))
+        (.releaseItem pool item)
+        (is (true? (timed-deref borrow-thread))
+            "timed out waiting for borrow thread to finish")))))
+
+(deftest pool-can-do-blocking-borrow-after-borrow-timed-out-during-lock
+  (testing (str "can do a blocking borrow from pool after previous borrow "
+                "timed out while a write lock was held")
+    (let [pool (create-populated-pool 1)]
+      (.lock pool)
+      (is (.isLocked pool))
+      (is (nil? (timed-deref
+                 (future (.borrowItemWithTimeout pool
+                                                 1
+                                                 TimeUnit/MICROSECONDS))))
+          "timed out waiting for borrow with timeout to finish")
+
+      (let [borrow-thread-started? (promise)
+            borrow-thread-borrowed? (promise)
+            borrow-thread (future (deliver borrow-thread-started? true)
+                                  (let [instance (.borrowItem pool)]
+                                    (deliver borrow-thread-borrowed? true)
+                                    (.releaseItem pool instance))
+                                  true)]
+        @borrow-thread-started?
+        (is (not (realized? borrow-thread-borrowed?)))
+        (.unlock pool)
+        (is (true? (timed-deref borrow-thread))
+            "timed out waiting for borrow thread to finish")
+        (is (not (.isLocked pool)))))))
+
+(deftest pool-can-borrow-after-borrow-interrupted-during-lock
+  (testing (str "can do a borrow after another borrow was interrupted "
+                "while a write lock was held")
+    (let [pool (create-populated-pool 1)
+          borrow-1 (.borrowItem pool)
+          borrow-thread-started-2 (promise)
+          borrow-thread-started-3? (promise)
+          lock-thread-locked? (promise)
+          borrow-thread-2 (future
+                           (deliver borrow-thread-started-2
+                                    (Thread/currentThread))
+                           (timed-deref lock-thread-locked?)
+                           (.borrowItem pool))
+          borrow-thread-3 (future
+                           (deliver borrow-thread-started-3? true)
+                           (timed-deref lock-thread-locked?)
+                           (.borrowItem pool))
+          borrow-thread-obj-2 @borrow-thread-started-2
+          _ @borrow-thread-started-3?
+          lock-thread-started? (promise)
+          unlock? (promise)
+          lock-thread (future
+                       (deliver lock-thread-started? true)
+                       (.lock pool)
+                       (deliver lock-thread-locked? true)
+                       @unlock?
+                       (.unlock pool)
+                       true)]
+      @lock-thread-started?
+      (.releaseItem pool borrow-1)
+      (is (true? (timed-deref lock-thread-locked?))
+          "timed out waiting for the lock to be acquired")
+      (is (true? (.isLocked pool)))
+      ;; Interrupt the second borrow thread so that it will stop waiting for the
+      ;; pool to be not empty and not locked.
+      (.interrupt borrow-thread-obj-2)
+      (is (thrown? ExecutionException (timed-deref borrow-thread-2))
+          "second borrow could not be interrupted")
+      (is (not (realized? borrow-thread-3)))
+      (deliver unlock? true)
+      (is (true? (timed-deref lock-thread))
+          "timed out waiting for the lock thread to finish")
+      (is (not (.isLocked pool)))
+      ;; If the third borrow doesn't block indefinitely, we've confirmed that
+      ;; the interruption of the second borrow while the write lock was
+      ;; held did not adversely affect the ability of the third borrow call
+      ;; to return.
+      (is (identical? borrow-1 (timed-deref borrow-thread-3))
+          (str "did not get back the same instance from the third borrow "
+               "attempt as was returned from the first borrow attempt")))))
+
+(deftest pool-can-borrow-after-borrow-timed-out-during-lock
+  (testing (str "can do a timed borrow from pool after previous borrow "
+                "timed out while a write lock was held")
+    (let [pool (create-populated-pool 1)
+          borrow-1 (.borrowItem pool)
+          borrow-thread-started-2? (promise)
+          borrow-thread-started-3? (promise)
+          lock-thread-locked? (promise)
+          borrow-thread-2 (future
+                           (deliver borrow-thread-started-2? true)
+                           (timed-deref lock-thread-locked?)
+                           (.borrowItemWithTimeout
+                            pool
+                            50
+                            TimeUnit/MILLISECONDS))
+          borrow-thread-3 (future
+                           (deliver borrow-thread-started-3? true)
+                           (timed-deref lock-thread-locked?)
+                           (.borrowItemWithTimeout pool
+                                                   1
+                                                   TimeUnit/SECONDS))
+          borrow2 @borrow-thread-started-2?
+          borrow3 @borrow-thread-started-3?
+          unlock? (promise)
+          lock-thread-started? (promise)
+          lock-thread (future
+                       (deliver lock-thread-started? true)
+                       (.lock pool)
+                       (deliver lock-thread-locked? true)
+                       @unlock?
+                       (.unlock pool)
+                       true)]
+      @lock-thread-started?
+      (.releaseItem pool borrow-1)
+      (is (true? (timed-deref lock-thread-locked?))
+          "timed out waiting for the lock to be acquired")
+      (is (.isLocked pool))
+      (is (nil? (timed-deref borrow-thread-2))
+          "second borrow attempt did not time out")
+      (deliver unlock? true)
+      (is (true? (timed-deref lock-thread))
+          "timed out waiting for the lock thread to finish")
+      (is (not (.isLocked pool)))
+      (is (identical? borrow-1 (timed-deref borrow-thread-3))
+          (str "did not get back the same instance from the third borrow"
+               "attempt as was returned from the first borrow attempt")))))
+
+(deftest pool-insert-pill-test
+  (testing "inserted pill is next item borrowed"
+    (let [pool (create-populated-pool 1)
+          pill (str "i'm a pill")]
+      (.insertPill pool pill)
+      (is (identical? (.borrowItem pool) pill))
+      (testing "subsequent borrows return the same pill"
+        (is (identical? (.borrowItem pool) pill)))))
+  (testing "when borrow is blocked, inserting a pill unblocks it"
+    (let [pool (create-populated-pool 1)
+          pill (str "I'm just a pill, yes I'm only a pill")
+          instance (.borrowItem pool)
+          blocked-borrow (future (.borrowItem pool))]
+      (is (= 0 (.size pool)))
+
+      ; Give future a chance to run and block
+      (Thread/sleep 500)
+      ; Pool is empty and the borrow future is blocked
+      (is (not (realized? blocked-borrow)))
+      ; inserting the pill should unblock the promise
+      (.insertPill pool pill)
+      ; borrow finishes and gives us back the pill
+      (let [future-result (timed-deref blocked-borrow)]
+        (is (identical? future-result pill)))))
+
+  (testing "second insert doesn't change the pill"
+    (let [pool (create-populated-pool 1)
+          first-pill (str "pill clinton")
+          second-pill (str "pillary clinton")]
+      (.insertPill pool first-pill)
+      (is (identical? first-pill (.borrowItem pool)))
+
+      (.insertPill pool second-pill)
+      ; Should still be equal to the first pill
+      (is (identical? first-pill (.borrowItem pool)))
+      (is (not (identical? second-pill (.borrowItem pool)))))))
+
+(deftest release-item-exceptions-test
+  (testing "releasing a different pill than the one that was inserted errors"
+    (let [pool (create-populated-pool 1)
+          first-pill (str "a city upon a pill")
+          second-pill (str "capitol pill")]
+      (.insertPill pool first-pill)
+      ; Only to show that it does not error
+      (is (nil? (.releaseItem pool first-pill)))
+      (is (thrown-with-msg?
+           IllegalArgumentException
+           #"The item being released is not registered with the pool"
+           (.releaseItem pool second-pill)))))
+
+  (testing "releasing a jruby not registered with the pool errors"
+    (let [pool (create-populated-pool 1)
+          not-in-pool-instance "I was never registered"]
+      (is (thrown-with-msg?
+           IllegalArgumentException
+           #"The item being released is not registered with the pool"
+           (.releaseItem pool not-in-pool-instance))))))
+
+(deftest lock-interrupted-by-pill-insertion-test
+  (testing "a call to .lock will throw if there is a pill"
+    (let [pool (create-populated-pool 1)
+          pill "pilliam shakespeare"]
+      (.insertPill pool pill)
+      (is (thrown-with-msg?
+           InterruptedException
+           #"Lock can't be granted because a pill has been inserted"
+           (.lock pool)))))
+
+  (testing "a blocked .lock call throws an InterruptedException once a pill is inserted"
+    (let [pool (create-populated-pool 1)
+          pill "pillful ignorance"]
+      ; Make it so the pool is not full
+      (.borrowItem pool)
+
+      ; Exceptions thrown from the future will be returned as InterruptedException,
+      ; so we can't use thrown-with-msg?. We'll catch it, return it instead of
+      ; throwing it, and inspect it manually below
+      (let [blocked-lock-future (future (try (.lock pool)
+                                             (catch InterruptedException e
+                                               e)))]
+        ; The future's thread will take the lock, and then block waiting for
+        ; either the pool to fill up, or a pill to be inserted
+        (jruby-testutils/wait-for-pool-to-be-locked pool)
+        (.insertPill pool pill)
+        (let [exception @blocked-lock-future]
+          (is (= InterruptedException (type exception)))
+          (is (= "Lock can't be granted because a pill has been inserted"
+                 (.getMessage exception))))))))
+
+(deftest pool-clear-test
+  (testing (str "pool clear removes all elements from queue and only matching"
+                "registered elements")
+    (let [pool (create-populated-pool 3)
+          instance (.borrowItem pool)]
+      (is (= 2 (.size pool)))
+      (is (= 1 (.. pool getRegisteredElements size)))
+      (.clear pool)
+      (is (= 3 (.size pool)))
+      (let [registered-elements (.getRegisteredElements pool)]
+        (is (= 1 (.size registered-elements)))
+        (is (identical? instance (-> registered-elements
+                                     (.iterator)
+                                     iterator-seq
+                                     first)))))))
+
+(deftest pool-remaining-capacity
+  (testing "remaining capacity in pool correct per instances in the queue"
+    (let [pool (create-populated-pool 5)]
+      (is (= 0 (.remainingCapacity pool)))
+      (let [instances (borrow-n-instances pool 2)]
+        (is (= 2 (.remainingCapacity pool)))
+        (return-instances pool instances)
+        (is (= 0 (.remainingCapacity pool)))))))

--- a/test/unit/puppetlabs/jruby_utils/lockable_ref_pool_test.clj
+++ b/test/unit/puppetlabs/jruby_utils/lockable_ref_pool_test.clj
@@ -645,10 +645,8 @@
       (is (= 0 (.. pool getRegisteredElements size))))))
 
 (deftest pool-remaining-capacity
-  (testing "remaining capacity in pool correct per instances in the queue"
-    (let [pool (create-populated-pool 5)]
-      (is (= 0 (.remainingCapacity pool)))
-      (let [instances (borrow-n-instances pool 2)]
-        (is (= 2 (.remainingCapacity pool)))
-        (return-instances pool instances)
-        (is (= 0 (.remainingCapacity pool)))))))
+  (testing "remaining capacity in pool correct per instances registered"
+    (let [empty-pool (create-empty-pool)
+          pool (create-populated-pool 5)]
+      (is (= 1 (.remainingCapacity empty-pool)))
+      (is (= 0 (.remainingCapacity pool))))))

--- a/test/unit/puppetlabs/services/jruby_pool_manager/jruby_reference_pool_test.clj
+++ b/test/unit/puppetlabs/services/jruby_pool_manager/jruby_reference_pool_test.clj
@@ -112,11 +112,11 @@
     (jruby-testutils/with-pool-context
       pool-context
       jruby-testutils/default-services
-      (jruby-testutils/jruby-config {:max-active-instances 4
-                                     :max-borrows-per-instance 10
-                                     :splay-instance-flush false
-                                     :borrow-timeout
-                                     test-borrow-timeout})
+      (jruby-testutils/jruby-config-for-ref-pool {:max-active-instances 4
+                                                  :max-borrows-per-instance 10
+                                                  :splay-instance-flush false
+                                                  :borrow-timeout
+                                                  test-borrow-timeout})
       (let [pool (jruby-core/get-pool pool-context)]
         ;; borrow the instance once and hold reference to it, to prevent
         ;; the flush operation from completing

--- a/test/unit/puppetlabs/services/jruby_pool_manager/jruby_reference_pool_test.clj
+++ b/test/unit/puppetlabs/services/jruby_pool_manager/jruby_reference_pool_test.clj
@@ -1,0 +1,83 @@
+(ns puppetlabs.services.jruby-pool-manager.jruby-reference-pool-test
+  (:require [clojure.test :refer :all]
+            [schema.test :as schema-test]
+            [puppetlabs.services.jruby-pool-manager.jruby-testutils :as jruby-testutils]
+            [puppetlabs.services.jruby-pool-manager.jruby-core :as jruby-core]
+            [puppetlabs.services.jruby-pool-manager.impl.jruby-agents :as jruby-agents]
+            [puppetlabs.services.jruby-pool-manager.impl.jruby-pool-manager-core :as jruby-pool-manager-core]
+            [puppetlabs.kitchensink.core :as ks])
+  (:import (puppetlabs.services.jruby_pool_manager.jruby_schemas JRubyInstance)))
+
+(deftest collect-all-jrubies-test
+  (testing "returns list of all the jruby instances"
+    (jruby-testutils/with-pool-context
+      pool-context
+      jruby-testutils/default-services
+      (jruby-testutils/jruby-config-for-ref-pool {:max-active-instances 4})
+      (let [pool (jruby-core/get-pool pool-context)
+            jruby-list (jruby-agents/borrow-all-jrubies pool-context)]
+        (try
+          (is (= 4 (count jruby-list)))
+          (is (every? #(instance? JRubyInstance %) jruby-list))
+          (is (= (first jruby-list) (last jruby-list)))
+          (is (= 0 (.size pool)))
+          (finally
+            (jruby-testutils/fill-drained-pool jruby-list)))))))
+
+(deftest test-jruby-core-funcs
+  (let [pool-size        2
+        timeout          250
+        config           (jruby-testutils/jruby-config-for-ref-pool {:max-active-instances pool-size
+                                                                     :borrow-timeout timeout})
+        pool-context (jruby-pool-manager-core/create-pool-context config)
+        pool             (jruby-core/get-pool pool-context)]
+    (testing "The pool should not yet be full as it is being primed in the
+             background."
+      (is (= (jruby-core/free-instance-count pool) 0))
+
+      (jruby-agents/prime-pool! pool-context)
+      (try
+        (testing "Borrowing all instances from a pool while it is being primed and
+             returning them."
+          (let [all-the-jrubys (jruby-testutils/drain-pool pool-context pool-size)]
+            (is (= 0 (jruby-core/free-instance-count pool)))
+            (doseq [instance all-the-jrubys]
+              (is (not (nil? instance)) "One of JRubyInstances is nil"))
+            (jruby-testutils/fill-drained-pool all-the-jrubys)
+            (is (= pool-size (jruby-core/free-instance-count pool)))))
+
+        (testing "Borrowing from an empty pool with a timeout returns nil within the
+             proper amount of time."
+          (let [all-the-jrubys (jruby-testutils/drain-pool pool-context pool-size)
+                test-start-in-millis (System/currentTimeMillis)]
+            (is (nil? (jruby-core/borrow-from-pool-with-timeout pool-context :test [])))
+            (is (>= (- (System/currentTimeMillis) test-start-in-millis) timeout)
+                "The timeout value was not honored.")
+            (jruby-testutils/fill-drained-pool all-the-jrubys)
+            (is (= (jruby-core/free-instance-count pool) pool-size)
+                "All JRubyInstances were not returned to the pool.")))
+
+        (testing "Removing an instance decrements the pool size by 1."
+          (let [jruby-instance (jruby-core/borrow-from-pool pool-context :test [])]
+            (is (= (jruby-core/free-instance-count pool) (dec pool-size)))
+            (jruby-core/return-to-pool jruby-instance :test [])))
+
+        (testing "Borrowing an instance increments its request count."
+          (let [drain-via (fn [borrow-fn] (doall (repeatedly pool-size borrow-fn)))
+                assoc-count (fn [acc jruby]
+                              (assoc acc (:id jruby)
+                                         (:borrow-count (jruby-core/get-instance-state jruby))))
+                get-counts (fn [jrubies] (reduce assoc-count {} jrubies))]
+            (doseq [drain-fn [#(jruby-core/borrow-from-pool pool-context :test [])
+                              #(jruby-core/borrow-from-pool-with-timeout pool-context :test [])]]
+              (let [jrubies (drain-via drain-fn)
+                    counts (get-counts jrubies)]
+                (jruby-testutils/fill-drained-pool jrubies)
+                (let [jrubies (drain-via drain-fn)
+                      new-counts (get-counts jrubies)]
+                  (jruby-testutils/fill-drained-pool jrubies)
+                  (is (= (ks/keyset counts) (ks/keyset new-counts)))
+                  (doseq [k (keys counts)]
+                    (is (= (inc (counts k)) (new-counts k)))))))))
+        (finally
+          (jruby-core/flush-pool-for-shutdown! pool-context))))))

--- a/test/unit/puppetlabs/services/jruby_pool_manager/jruby_reference_pool_test.clj
+++ b/test/unit/puppetlabs/services/jruby_pool_manager/jruby_reference_pool_test.clj
@@ -62,7 +62,7 @@
             (is (= (jruby-core/free-instance-count pool) (dec pool-size)))
             (jruby-core/return-to-pool jruby-instance :test [])))
 
-        (testing "Borrowing an instance increments its request count."
+        (testing "Borrowing the instance increments its request count."
           (let [drain-via (fn [borrow-fn] (doall (repeatedly pool-size borrow-fn)))
                 assoc-count (fn [acc jruby]
                               (assoc acc (:id jruby)
@@ -78,6 +78,101 @@
                   (jruby-testutils/fill-drained-pool jrubies)
                   (is (= (ks/keyset counts) (ks/keyset new-counts)))
                   (doseq [k (keys counts)]
-                    (is (= (inc (counts k)) (new-counts k)))))))))
+                    ;; The instance has been borrowed twice, since we allow two borrows (size of pool is 2)
+                    ;; and we borrow up to our limit in `drain-via`
+                    (is (= (+ 2 (counts k)) (new-counts k)))))))))
         (finally
           (jruby-core/flush-pool-for-shutdown! pool-context))))))
+
+(def test-borrow-timeout 180000)
+
+(defn set-constant-and-verify
+  [instance]
+  ;; here we set a variable called 'seen' in the instance
+  (let [sc (:scripting-container instance)
+        result (.runScriptlet sc "$seen = true")]
+    ;; and validate that we can read that value back from each instance
+    (= true (.runScriptlet sc "$seen"))))
+
+(defn check-all-jrubies-for-constants
+  [pool-context num-instances]
+  (jruby-testutils/reduce-over-jrubies!
+    pool-context
+    num-instances
+    (constantly "! $seen.nil?")))
+
+(defn verify-no-constants
+  [pool-context]
+  ;; verify that the constants are cleared out from the instances by looping
+  ;; over them and expecting a 'NameError' when we reference the constant by name.
+  (every? false? (check-all-jrubies-for-constants pool-context 1)))
+
+(deftest ^:integration max-borrows-flush-while-pool-flush-in-progress-test
+  (testing "hitting max-borrows while flush in progress doesn't interfere with flush"
+    (jruby-testutils/with-pool-context
+      pool-context
+      jruby-testutils/default-services
+      (jruby-testutils/jruby-config {:max-active-instances 4
+                                     :max-borrows-per-instance 10
+                                     :splay-instance-flush false
+                                     :borrow-timeout
+                                     test-borrow-timeout})
+      (let [pool (jruby-core/get-pool pool-context)]
+        ;; borrow the instance once and hold reference to it, to prevent
+        ;; the flush operation from completing
+        (let [reference1 (jruby-core/borrow-from-pool-with-timeout
+                            pool-context
+                            :max-borrows-flush-while-pool-flush-in-progress-test
+                            [])]
+          ;; Mark the instance so we can verify it gets flushed out later
+          (is (true? (set-constant-and-verify reference1)))
+          ;; we are going to borrow and return a second reference until we get its
+          ;; request count up to max-borrows - 1, so that we can use it to test
+          ;; flushing behavior the next time we return it.
+          (is (true? (jruby-testutils/borrow-until-desired-borrow-count pool-context 9)))
+          ;; now we grub a reference to that instance and hold onto it for later.
+          (let [reference2 (jruby-core/borrow-from-pool-with-timeout
+                              pool-context
+                              :max-borrows-flush-while-pool-flush-in-progress-test
+                              [])]
+            (is (= 9 (:borrow-count (jruby-core/get-instance-state reference2))))
+            (is (= 2 (jruby-core/free-instance-count pool)))
+
+            ; Just to show that the pool is not locked yet
+            (is (not (.isLocked pool)))
+            ;; trigger a flush asynchronously
+            (let [flush-future (future (jruby-core/flush-pool! pool-context))]
+              ;; Once the lock is held this means that the flush is waiting
+              ;; for all the instances to be returned before continuing
+              (is (jruby-testutils/wait-for-pool-to-be-locked pool))
+
+              ;; now we're going to return instance2 to the pool.  This would trigger a flush
+              ;; (before the one we requested) but we're still holding on to another reference
+              ;; to this instance, so it can't proceed.
+              (jruby-core/return-to-pool reference2
+                                         :max-borrows-flush-while-pool-flush-in-progress-test
+                                         [])
+              ;; Wait until instance2 is returned
+              (is (jruby-testutils/wait-for-instances pool 3) "Timed out waiting for instance2 to return to pool")
+
+              ;; and finally, we return the last instance we borrowed to the pool
+              (jruby-core/return-to-pool reference1
+                                         :max-borrows-flush-while-pool-flush-in-progress-test
+                                         [])
+
+              ;; wait until the flush is complete
+              (is (deref flush-future 10000 false))
+              (is (not (.isLocked pool)))
+
+              (is (jruby-testutils/wait-for-instances pool 4) "Timed out waiting for the flush to finish"))))
+
+        ;; we should have a fresh instance without the constant.
+        (is (true? (verify-no-constants pool-context)))
+
+        ;; The jruby return instance calls done within the previous
+        ;; check jrubies call may cause an instance to be in the process of
+        ;; being flushed when the server is shut down.  This ensures that
+        ;; the flushing is all done before the server is shut down - since
+        ;; that could otherwise cause an annoying error message about the
+        ;; pool not being full at shut down to be displayed.
+        (jruby-testutils/timed-await (jruby-agents/get-modify-instance-agent pool-context))))))

--- a/test/unit/puppetlabs/services/jruby_pool_manager/jruby_testutils.clj
+++ b/test/unit/puppetlabs/services/jruby_pool_manager/jruby_testutils.clj
@@ -40,6 +40,13 @@
             :borrow-timeout 300000}
            options))))
 
+(schema/defn ^:always-validate
+ jruby-config-for-ref-pool :- jruby-schemas/JRubyConfig
+  ([]
+   (jruby-config {:multithreaded true}))
+  ([options]
+   (jruby-config (merge options {:multithreaded true}))))
+
 (defn drain-pool
   "Drains the JRuby pool and returns each instance in a vector."
   [pool-context size]


### PR DESCRIPTION
This work creates a second implementation of a LockablePool, that hands out references to a single JRuby instance, instead of handing out multiple instances one at a time. This can be toggled via a `multithreaded` config value. It adds one additional setting, `max-concurrent-thread-count`, which controls how many references the ReferencePool may hand out at once.

It still needs more testing, partially in the form of a refactor of the existing tests, splitting some of them out because they apply only to the JRubyPool and not the ReferencePool paradigm (a good example of splayed flushing of instances) or vice versa. I also haven't done any high-level (e.g. in puppetserver) testing yet.

But before I do all that, I thought I'd put this up, so people can take a look at the approach and provide initial feedback on whether we think this is better than proceeding down the route started in https://github.com/puppetlabs/puppetserver/pull/2143. The semantics here are _almost_ right in most cases, and could probably be reworded in some places to reduce misleading descriptions and names. But it's also possible that this is conflating two ideas that are too dissimilar to warrant trying to jam them into one abstraction.