### PR TITLE
(SERVER-2529) Clojure Reference Pool

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject puppetlabs/jruby-utils "2.3.3-SNAPSHOT"
+(defproject puppetlabs/jruby-utils "3.0.0-SNAPSHOT"
   :description "A library for working with JRuby"
   :url "https://github.com/puppetlabs/jruby-utils"
   :license {:name "Apache License, Version 2.0"

--- a/src/clj/puppetlabs/services/jruby_pool_manager/impl/instance_pool.clj
+++ b/src/clj/puppetlabs/services/jruby_pool_manager/impl/instance_pool.clj
@@ -46,7 +46,7 @@
     [pool-context instance]
     (when (jruby-schemas/jruby-instance? instance)
       (let [new-state (swap! (jruby-internal/get-instance-state-container instance)
-                             update-in [:borrow-count] inc)
+                             #(update-in % [:borrow-count] inc))
             {:keys [initial-borrows max-borrows pool]} (:internal instance)
             borrow-limit (or initial-borrows max-borrows)]
         (if (and (pos? borrow-limit)

--- a/src/clj/puppetlabs/services/jruby_pool_manager/impl/instance_pool.clj
+++ b/src/clj/puppetlabs/services/jruby_pool_manager/impl/instance_pool.clj
@@ -52,5 +52,9 @@
                           (:id instance)
                           borrow-limit))
             (jruby-agents/send-flush-instance! this instance))
-          (.releaseItem pool instance))))))
+          (.releaseItem pool instance)))))
+
+  (flush-pool
+    [this]
+    (jruby-agents/flush-and-repopulate-pool! this)))
 

--- a/src/clj/puppetlabs/services/jruby_pool_manager/impl/instance_pool.clj
+++ b/src/clj/puppetlabs/services/jruby_pool_manager/impl/instance_pool.clj
@@ -35,7 +35,9 @@
       (.unlock pool)))
 
   (borrow
-    [this])
+    [this]
+    (let [pool (jruby-internal/get-pool this)]
+      (.borrowItem pool)))
 
   (return
     [this instance]

--- a/src/clj/puppetlabs/services/jruby_pool_manager/impl/instance_pool.clj
+++ b/src/clj/puppetlabs/services/jruby_pool_manager/impl/instance_pool.clj
@@ -50,7 +50,7 @@
                  (>= (:borrow-count new-state) borrow-limit))
           (do
             (log/info
-                (i18n/trs "Flushing JRubyInstance {0} because it has exceeded its borrow limit of ({1})"
+                (i18n/trs "Flushing JRubyInstance {0} because it has exceeded its borrow limit of {1}"
                           (:id instance)
                           borrow-limit))
             (jruby-agents/send-flush-instance! this instance))

--- a/src/clj/puppetlabs/services/jruby_pool_manager/impl/instance_pool.clj
+++ b/src/clj/puppetlabs/services/jruby_pool_manager/impl/instance_pool.clj
@@ -1,0 +1,33 @@
+(ns puppetlabs.services.jruby-pool-manager.impl.instance-pool
+  (:require [puppetlabs.services.jruby-pool-manager.impl.jruby-agents :as jruby-agents]
+            [puppetlabs.services.protocols.jruby-pool :as pool-protocol])
+  (:import (puppetlabs.services.protocols.jruby_pool JRubyPool)
+           (puppetlabs.services.jruby_pool_manager.jruby_schemas InstancePool)))
+
+(extend-type InstancePool
+  pool-protocol/JRubyPool
+  (fill
+    [this]
+    (jruby-agents/send-prime-pool! this))
+
+  (shutdown
+    [this]
+    (jruby-agents/flush-pool-for-shutdown! this))
+
+  (lock
+    [this])
+
+  (unlock
+    [this])
+
+  (add-instance
+    [this instance])
+
+  (remove-instance
+    [this instance])
+
+  (borrow
+    [this])
+
+  (return
+    [this instance]))

--- a/src/clj/puppetlabs/services/jruby_pool_manager/impl/instance_pool.clj
+++ b/src/clj/puppetlabs/services/jruby_pool_manager/impl/instance_pool.clj
@@ -1,7 +1,10 @@
 (ns puppetlabs.services.jruby-pool-manager.impl.instance-pool
   (:require [puppetlabs.services.jruby-pool-manager.impl.jruby-agents :as jruby-agents]
             [puppetlabs.services.protocols.jruby-pool :as pool-protocol]
-            [puppetlabs.services.jruby-pool-manager.impl.jruby-internal :as jruby-internal])
+            [puppetlabs.services.jruby-pool-manager.impl.jruby-internal :as jruby-internal]
+            [puppetlabs.services.jruby-pool-manager.jruby-schemas :as jruby-schemas]
+            [clojure.tools.logging :as log]
+            [puppetlabs.i18n.core :as i18n])
   (:import (puppetlabs.services.jruby_pool_manager.jruby_schemas InstancePool)))
 
 (extend-type InstancePool
@@ -35,6 +38,19 @@
     [this])
 
   (return
-    [_ instance]
-    (jruby-internal/return-to-pool instance)))
+    [this instance]
+    (when (jruby-schemas/jruby-instance? instance)
+      (let [new-state (swap! (jruby-internal/get-instance-state-container instance)
+                             update-in [:borrow-count] inc)
+            {:keys [initial-borrows max-borrows pool]} (:internal instance)
+            borrow-limit (or initial-borrows max-borrows)]
+        (if (and (pos? borrow-limit)
+                 (>= (:borrow-count new-state) borrow-limit))
+          (do
+            (log/info
+                (i18n/trs "Flushing JRubyInstance {0} because it has exceeded its borrow limit of ({1})"
+                          (:id instance)
+                          borrow-limit))
+            (jruby-agents/send-flush-instance! this instance))
+          (.releaseItem pool instance))))))
 

--- a/src/clj/puppetlabs/services/jruby_pool_manager/impl/instance_pool.clj
+++ b/src/clj/puppetlabs/services/jruby_pool_manager/impl/instance_pool.clj
@@ -1,6 +1,7 @@
 (ns puppetlabs.services.jruby-pool-manager.impl.instance-pool
   (:require [puppetlabs.services.jruby-pool-manager.impl.jruby-agents :as jruby-agents]
-            [puppetlabs.services.protocols.jruby-pool :as pool-protocol])
+            [puppetlabs.services.protocols.jruby-pool :as pool-protocol]
+            [puppetlabs.services.jruby-pool-manager.impl.jruby-internal :as jruby-internal])
   (:import (puppetlabs.services.jruby_pool_manager.jruby_schemas InstancePool)))
 
 (extend-type InstancePool
@@ -16,10 +17,19 @@
     (jruby-agents/flush-pool-for-shutdown! this))
 
   (lock
-    [this])
+    [this]
+    (let [pool (jruby-internal/get-pool this)]
+      (.lock pool)))
+
+  (lock-with-timeout
+    [this timeout time-unit]
+    (let [pool (jruby-internal/get-pool this)]
+      (.lockWithTimeout pool timeout time-unit)))
 
   (unlock
-    [this])
+    [this]
+    (let [pool (jruby-internal/get-pool this)]
+      (.unlock pool)))
 
   (add-instance
     [this instance])

--- a/src/clj/puppetlabs/services/jruby_pool_manager/impl/instance_pool.clj
+++ b/src/clj/puppetlabs/services/jruby_pool_manager/impl/instance_pool.clj
@@ -32,7 +32,7 @@
       (.unlock pool)))
 
   (add-instance
-    [this instance])
+    [this id])
 
   (remove-instance
     [this instance])
@@ -41,4 +41,6 @@
     [this])
 
   (return
-    [this instance]))
+    [_ instance]
+    (jruby-internal/return-to-pool instance)))
+

--- a/src/clj/puppetlabs/services/jruby_pool_manager/impl/instance_pool.clj
+++ b/src/clj/puppetlabs/services/jruby_pool_manager/impl/instance_pool.clj
@@ -31,12 +31,6 @@
     (let [pool (jruby-internal/get-pool this)]
       (.unlock pool)))
 
-  (add-instance
-    [this id])
-
-  (remove-instance
-    [this instance])
-
   (borrow
     [this])
 

--- a/src/clj/puppetlabs/services/jruby_pool_manager/impl/instance_pool.clj
+++ b/src/clj/puppetlabs/services/jruby_pool_manager/impl/instance_pool.clj
@@ -36,8 +36,11 @@
 
   (borrow
     [this]
-    (let [pool (jruby-internal/get-pool this)]
-      (.borrowItem pool)))
+    (jruby-internal/borrow-from-pool this))
+
+  (borrow-with-timeout
+    [this timeout]
+    (jruby-internal/borrow-from-pool-with-timeout this timeout))
 
   (return
     [this instance]

--- a/src/clj/puppetlabs/services/jruby_pool_manager/impl/instance_pool.clj
+++ b/src/clj/puppetlabs/services/jruby_pool_manager/impl/instance_pool.clj
@@ -1,14 +1,15 @@
 (ns puppetlabs.services.jruby-pool-manager.impl.instance-pool
   (:require [puppetlabs.services.jruby-pool-manager.impl.jruby-agents :as jruby-agents]
             [puppetlabs.services.protocols.jruby-pool :as pool-protocol])
-  (:import (puppetlabs.services.protocols.jruby_pool JRubyPool)
-           (puppetlabs.services.jruby_pool_manager.jruby_schemas InstancePool)))
+  (:import (puppetlabs.services.jruby_pool_manager.jruby_schemas InstancePool)))
 
 (extend-type InstancePool
   pool-protocol/JRubyPool
   (fill
     [this]
-    (jruby-agents/send-prime-pool! this))
+    (let [modify-instance-agent (jruby-agents/get-modify-instance-agent this)]
+      (jruby-agents/send-agent modify-instance-agent
+                               #(jruby-agents/prime-pool! this))))
 
   (shutdown
     [this]

--- a/src/clj/puppetlabs/services/jruby_pool_manager/impl/jruby_agents.clj
+++ b/src/clj/puppetlabs/services/jruby_pool_manager/impl/jruby_agents.clj
@@ -48,14 +48,15 @@
 (schema/defn add-instance
   [{:keys [config] :as pool-context} :- jruby-schemas/PoolContext
    id :- schema/Int]
-  (let [pool (jruby-internal/get-pool pool-context)]
+  (let [pool (jruby-internal/get-pool pool-context)
+        instance-count (jruby-internal/get-pool-size pool-context)]
     (try
       (log/debug (i18n/trs "Priming JRubyInstance {0} of {1}"
-                           id count))
+                           id instance-count))
       (jruby-internal/create-pool-instance! pool id config
                                             (:splay-instance-flush config))
       (log/info (i18n/trs "Finished creating JRubyInstance {0} of {1}"
-                          id count))
+                          id instance-count))
       (catch Exception e
         (.clear pool)
         (jruby-internal/insert-poison-pill pool e)

--- a/src/clj/puppetlabs/services/jruby_pool_manager/impl/jruby_agents.clj
+++ b/src/clj/puppetlabs/services/jruby_pool_manager/impl/jruby_agents.clj
@@ -232,13 +232,6 @@
   (agent {:shutdown-on-error shutdown-on-error-fn}))
 
 (schema/defn ^:always-validate
-  send-prime-pool! :- jruby-schemas/JRubyPoolAgent
-  "Sends a request to the agent to prime the pool using the given pool context."
-  [pool-context :- jruby-schemas/PoolContext]
-  (let [modify-instance-agent (get-modify-instance-agent pool-context)]
-    (send-agent modify-instance-agent #(prime-pool! pool-context))))
-
-(schema/defn ^:always-validate
   flush-and-repopulate-pool!
   "Flush of the current JRuby pool. Blocks until all the instances have
   been borrowed from the pool, but does not wait for the instances

--- a/src/clj/puppetlabs/services/jruby_pool_manager/impl/jruby_internal.clj
+++ b/src/clj/puppetlabs/services/jruby_pool_manager/impl/jruby_internal.clj
@@ -10,7 +10,7 @@
             [puppetlabs.services.jruby-pool-manager.jruby-schemas :as jruby-schemas]
             [schema.core :as schema])
   (:import (clojure.lang IFn)
-           (com.puppetlabs.jruby_utils.pool JRubyPool)
+           (com.puppetlabs.jruby_utils.pool JRubyPool ReferencePool)
            (com.puppetlabs.jruby_utils.jruby InternalScriptingContainer
                                              ScriptingContainer)
            (java.io File)
@@ -41,7 +41,7 @@
   "Instantiate a new queue object to use as the pool of free JRuby's."
   [max-concurrent-borrows]
   {:post [(instance? jruby-schemas/pool-queue-type %)]}
-  (JRubyPool. max-concurrent-borrows))
+  (ReferencePool. max-concurrent-borrows))
 
 (schema/defn ^:always-validate get-compile-mode :- RubyInstanceConfig$CompileMode
   [config-compile-mode :- jruby-schemas/SupportedJRubyCompileModes]
@@ -277,7 +277,7 @@
   get-pool-size :- schema/Int
   "Gets the size of the JRuby pool from the pool context."
   [context :- jruby-schemas/PoolContext]
-  (get-in context [:config :max-active-instances]))
+  (:size (get-pool-state context)))
 
 (schema/defn ^:always-validate
   get-flush-timeout :- schema/Int

--- a/src/clj/puppetlabs/services/jruby_pool_manager/impl/jruby_pool_manager_core.clj
+++ b/src/clj/puppetlabs/services/jruby_pool_manager/impl/jruby_pool_manager_core.clj
@@ -2,22 +2,28 @@
   (:require [schema.core :as schema]
             [puppetlabs.services.jruby-pool-manager.jruby-schemas :as jruby-schemas]
             [puppetlabs.services.jruby-pool-manager.impl.jruby-agents :as jruby-agents]
-            [puppetlabs.services.jruby-pool-manager.impl.jruby-internal :as jruby-internal]))
+            [puppetlabs.services.protocols.jruby-pool :as pool-protocol]
+            [puppetlabs.services.jruby-pool-manager.impl.reference-pool]
+            [puppetlabs.services.jruby-pool-manager.impl.instance-pool]
+            [puppetlabs.services.jruby-pool-manager.impl.jruby-internal :as jruby-internal])
+  (:import (puppetlabs.services.jruby_pool_manager.jruby_schemas ReferencePool InstancePool)))
 
 (schema/defn ^:always-validate
   create-pool-context :- jruby-schemas/PoolContext
   "Creates a new JRuby pool context with an empty pool. Once the JRuby
   pool object has been created, it will need to be filled using `prime-pool!`."
   [config :- jruby-schemas/JRubyConfig]
-  (let [shutdown-on-error-fn (get-in config [:lifecycle :shutdown-on-error])]
-    {:config config
-     :internal {:modify-instance-agent (jruby-agents/pool-agent shutdown-on-error-fn)
-                :pool-state (atom (jruby-internal/create-pool-from-config config))
-                :event-callbacks (atom [])}}))
+  (let [shutdown-on-error-fn (get-in config [:lifecycle :shutdown-on-error])
+        internal {:modify-instance-agent (jruby-agents/pool-agent shutdown-on-error-fn)
+                  :pool-state            (atom (jruby-internal/create-pool-from-config config))
+                  :event-callbacks       (atom [])}]
+    (if (:multithreaded config)
+      (ReferencePool. config internal)
+      (InstancePool. config internal))))
 
 (schema/defn ^:always-validate
   create-pool :- jruby-schemas/PoolContext
   [config :- jruby-schemas/JRubyConfig]
   (let [pool-context (create-pool-context config)]
-     (jruby-agents/send-prime-pool! pool-context)
+     (pool-protocol/fill pool-context)
      pool-context))

--- a/src/clj/puppetlabs/services/jruby_pool_manager/impl/jruby_pool_manager_core.clj
+++ b/src/clj/puppetlabs/services/jruby_pool_manager/impl/jruby_pool_manager_core.clj
@@ -18,7 +18,7 @@
                   :pool-state            (atom (jruby-internal/create-pool-from-config config))
                   :event-callbacks       (atom [])}]
     (if (:multithreaded config)
-      (ReferencePool. config internal)
+      (ReferencePool. config internal (atom 0))
       (InstancePool. config internal))))
 
 (schema/defn ^:always-validate

--- a/src/clj/puppetlabs/services/jruby_pool_manager/impl/reference_pool.clj
+++ b/src/clj/puppetlabs/services/jruby_pool_manager/impl/reference_pool.clj
@@ -12,7 +12,7 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Private
 
-(schema/defn flush-pool
+(schema/defn flush-pool*
   "Flushes the pool, assuming it has already been locked by the calling function.
   Do not call this without first locking the pool, or the flush may never complete,
   since it requires that all references be returned to proceed."
@@ -47,7 +47,7 @@
       ;; Now that we've successfully acquired the lock, check the borrows again
       ;; to make sure the pool wasn't flushed while we were waiting.
       (when (max-borrows-exceeded @borrow-count max-borrows)
-        (flush-pool pool-context))
+        (flush-pool* pool-context))
       (finally
         (pool-protocol/unlock pool-context)))))
 
@@ -113,7 +113,7 @@
     [pool-context]
     (pool-protocol/lock pool-context)
     (try
-      (flush-pool pool-context)
+      (flush-pool* pool-context)
       (finally
         (pool-protocol/unlock pool-context)))))
 

--- a/src/clj/puppetlabs/services/jruby_pool_manager/impl/reference_pool.clj
+++ b/src/clj/puppetlabs/services/jruby_pool_manager/impl/reference_pool.clj
@@ -41,8 +41,11 @@
 
   (borrow
     [this]
-    (let [pool (jruby-internal/get-pool this)]
-      (.borrowItem pool)))
+    (jruby-internal/borrow-from-pool this))
+
+  (borrow-with-timeout
+    [this timeout]
+    (jruby-internal/borrow-from-pool-with-timeout this timeout))
 
   (return
     [this instance]

--- a/src/clj/puppetlabs/services/jruby_pool_manager/impl/reference_pool.clj
+++ b/src/clj/puppetlabs/services/jruby_pool_manager/impl/reference_pool.clj
@@ -6,11 +6,15 @@
 
 (extend-type ReferencePool
   pool-protocol/JRubyPool
+  (add-instance
+    ([this id]
+     (jruby-agents/add-instance this id)))
+
   (fill
     [this]
     (let [modify-instance-agent (jruby-agents/get-modify-instance-agent this)]
       (jruby-agents/send-agent modify-instance-agent
-                               #(jruby-agents/add-instance this 1))))
+                               #(pool-protocol/add-instance this 1))))
 
   (shutdown
     [this])

--- a/src/clj/puppetlabs/services/jruby_pool_manager/impl/reference_pool.clj
+++ b/src/clj/puppetlabs/services/jruby_pool_manager/impl/reference_pool.clj
@@ -30,7 +30,9 @@
 
   (fill
     [pool-context]
-    (jruby-agents/add-instance pool-context 1))
+    (let [modify-instance-agent (jruby-agents/get-modify-instance-agent pool-context)]
+      (jruby-agents/send-agent modify-instance-agent
+                               #(jruby-agents/add-instance pool-context 1))))
 
   (shutdown
     [pool-context]

--- a/src/clj/puppetlabs/services/jruby_pool_manager/impl/reference_pool.clj
+++ b/src/clj/puppetlabs/services/jruby_pool_manager/impl/reference_pool.clj
@@ -6,15 +6,11 @@
 
 (extend-type ReferencePool
   pool-protocol/JRubyPool
-  (add-instance
-    ([this id]
-     (jruby-agents/add-instance this id)))
-
   (fill
     [this]
     (let [modify-instance-agent (jruby-agents/get-modify-instance-agent this)]
       (jruby-agents/send-agent modify-instance-agent
-                               #(pool-protocol/add-instance this 1))))
+                               #(jruby-agents/add-instance this 1))))
 
   (shutdown
     [this])

--- a/src/clj/puppetlabs/services/jruby_pool_manager/impl/reference_pool.clj
+++ b/src/clj/puppetlabs/services/jruby_pool_manager/impl/reference_pool.clj
@@ -1,6 +1,7 @@
 (ns puppetlabs.services.jruby-pool-manager.impl.reference-pool
   (:require [puppetlabs.services.protocols.jruby-pool :as pool-protocol]
-            [puppetlabs.services.jruby-pool-manager.impl.jruby-agents :as jruby-agents])
+            [puppetlabs.services.jruby-pool-manager.impl.jruby-agents :as jruby-agents]
+            [puppetlabs.services.jruby-pool-manager.impl.jruby-internal :as jruby-internal])
   (:import (puppetlabs.services.jruby_pool_manager.jruby_schemas ReferencePool)))
 
 (extend-type ReferencePool
@@ -15,10 +16,19 @@
     [this])
 
   (lock
-    [this])
+    [this]
+    (let [pool (jruby-internal/get-pool this)]
+      (.lock pool)))
+
+  (lock-with-timeout
+    [this timeout time-unit]
+    (let [pool (jruby-internal/get-pool this)]
+      (.lockWithTimeout pool timeout time-unit)))
 
   (unlock
-    [this])
+    [this]
+    (let [pool (jruby-internal/get-pool this)]
+      (.unlock pool)))
 
   (add-instance
     [this instance])

--- a/src/clj/puppetlabs/services/jruby_pool_manager/impl/reference_pool.clj
+++ b/src/clj/puppetlabs/services/jruby_pool_manager/impl/reference_pool.clj
@@ -6,6 +6,7 @@
 
 (extend-type ReferencePool
   pool-protocol/JRubyPool
+
   (fill
     [this]
     (let [modify-instance-agent (jruby-agents/get-modify-instance-agent this)]
@@ -13,7 +14,14 @@
                                #(jruby-agents/add-instance this 1))))
 
   (shutdown
-    [this])
+    [this]
+    (let [pool (jruby-internal/get-pool this)
+          cleanup-fn (get-in this [:config :lifecycle :cleanup])
+          instance (.borrowItem pool)
+          _ (.releaseItem pool instance)]
+      (jruby-internal/insert-shutdown-poison-pill pool)
+      ;; This will block until all borrows have been returned
+      (jruby-internal/cleanup-pool-instance! instance cleanup-fn)))
 
   (lock
     [this]
@@ -31,7 +39,44 @@
       (.unlock pool)))
 
   (borrow
-    [this])
+    [this]
+    (let [pool (jruby-internal/get-pool this)]
+      (.borrowItem pool)))
 
   (return
-    [this instance]))
+    [this instance]
+    (let [pool (jruby-internal/get-pool this)
+          borrow-count (:borrow-count this)
+          max-borrows (get-in instance [:internal :max-borrows])
+          modify-instance-agent (jruby-agents/get-modify-instance-agent this)]
+      (.releaseItem pool instance)
+      (swap! borrow-count inc)
+      ;; If max-borrows is 0, never flush the instance
+      (when (and (pos? max-borrows)
+                 (>= @borrow-count max-borrows)
+                 ;; If the pool is already locked, there's a good chance
+                 ;; a flush is already in progress, and we shouldn't queue
+                 ;; another one. If the pool is locked for some other reason,
+                 ;; we'll flush later. `borrow-count` does not get set back to
+                 ;; 0 until a flush succeeds.
+                 (not (.isLocked pool)))
+        (jruby-agents/send-agent modify-instance-agent #(pool-protocol/flush-pool this)))))
+
+  (flush-pool
+    [this]
+    (pool-protocol/lock this)
+    (try
+      (let [pool (jruby-internal/get-pool this)
+            borrow-count (:borrow-count this)
+            cleanup-fn (get-in this [:config :lifecycle :cleanup])
+            old-instance (.borrowItem pool)
+            prev-id (:id old-instance)
+            _ (.releaseItem pool old-instance)]
+        ;; This will block waiting for all borrows to be returned
+        (jruby-internal/cleanup-pool-instance! old-instance cleanup-fn)
+        (jruby-agents/add-instance this (inc prev-id))
+        (reset! borrow-count 0))
+      (finally
+        (pool-protocol/unlock this)))))
+
+

--- a/src/clj/puppetlabs/services/jruby_pool_manager/impl/reference_pool.clj
+++ b/src/clj/puppetlabs/services/jruby_pool_manager/impl/reference_pool.clj
@@ -34,12 +34,6 @@
     (let [pool (jruby-internal/get-pool this)]
       (.unlock pool)))
 
-  (add-instance
-    [this instance])
-
-  (remove-instance
-    [this instance])
-
   (borrow
     [this])
 

--- a/src/clj/puppetlabs/services/jruby_pool_manager/impl/reference_pool.clj
+++ b/src/clj/puppetlabs/services/jruby_pool_manager/impl/reference_pool.clj
@@ -9,9 +9,7 @@
 
   (fill
     [this]
-    (let [modify-instance-agent (jruby-agents/get-modify-instance-agent this)]
-      (jruby-agents/send-agent modify-instance-agent
-                               #(jruby-agents/add-instance this 1))))
+    (jruby-agents/add-instance this 1))
 
   (shutdown
     [this]
@@ -59,6 +57,7 @@
                  ;; another one. If the pool is locked for some other reason,
                  ;; we'll flush later. `borrow-count` does not get set back to
                  ;; 0 until a flush succeeds.
+                 ;; THIS IS RACY
                  (not (.isLocked pool)))
         (jruby-agents/send-agent modify-instance-agent #(pool-protocol/flush-pool this)))))
 

--- a/src/clj/puppetlabs/services/jruby_pool_manager/impl/reference_pool.clj
+++ b/src/clj/puppetlabs/services/jruby_pool_manager/impl/reference_pool.clj
@@ -1,11 +1,15 @@
 (ns puppetlabs.services.jruby-pool-manager.impl.reference-pool
-  (:require [puppetlabs.services.protocols.jruby-pool :as pool-protocol])
+  (:require [puppetlabs.services.protocols.jruby-pool :as pool-protocol]
+            [puppetlabs.services.jruby-pool-manager.impl.jruby-agents :as jruby-agents])
   (:import (puppetlabs.services.jruby_pool_manager.jruby_schemas ReferencePool)))
 
 (extend-type ReferencePool
   pool-protocol/JRubyPool
   (fill
-    [this])
+    [this]
+    (let [modify-instance-agent (jruby-agents/get-modify-instance-agent this)]
+      (jruby-agents/send-agent modify-instance-agent
+                               #(jruby-agents/add-instance this 1))))
 
   (shutdown
     [this])

--- a/src/clj/puppetlabs/services/jruby_pool_manager/impl/reference_pool.clj
+++ b/src/clj/puppetlabs/services/jruby_pool_manager/impl/reference_pool.clj
@@ -1,0 +1,29 @@
+(ns puppetlabs.services.jruby-pool-manager.impl.reference-pool
+  (:require [puppetlabs.services.protocols.jruby-pool :as pool-protocol])
+  (:import (puppetlabs.services.jruby_pool_manager.jruby_schemas ReferencePool)))
+
+(extend-type ReferencePool
+  pool-protocol/JRubyPool
+  (fill
+    [this])
+
+  (shutdown
+    [this])
+
+  (lock
+    [this])
+
+  (unlock
+    [this])
+
+  (add-instance
+    [this instance])
+
+  (remove-instance
+    [this instance])
+
+  (borrow
+    [this])
+
+  (return
+    [this instance]))

--- a/src/clj/puppetlabs/services/jruby_pool_manager/jruby_core.clj
+++ b/src/clj/puppetlabs/services/jruby_pool_manager/jruby_core.clj
@@ -239,14 +239,14 @@
   flush-pool!
   "Flush all the current JRubyInstances and repopulate the pool."
   [pool-context]
-  (jruby-agents/flush-and-repopulate-pool! pool-context))
+  (pool-protocol/flush-pool pool-context))
 
 (schema/defn ^:always-validate
   flush-pool-for-shutdown!
   "Flush all the current JRubyInstances so that the pool can be shutdown
   without any instances being active."
   [pool-context]
-  (jruby-agents/flush-pool-for-shutdown! pool-context))
+  (pool-protocol/shutdown pool-context))
 
 (schema/defn ^:always-validate
   lock-pool

--- a/src/clj/puppetlabs/services/jruby_pool_manager/jruby_core.clj
+++ b/src/clj/puppetlabs/services/jruby_pool_manager/jruby_core.clj
@@ -11,7 +11,8 @@
             [clojure.tools.logging :as log]
             [slingshot.slingshot :as sling]
             [puppetlabs.i18n.core :as i18n]
-            [me.raynes.fs :as fs])
+            [me.raynes.fs :as fs]
+            [puppetlabs.services.protocols.jruby-pool :as pool-protocol])
   (:import (puppetlabs.services.jruby_pool_manager.jruby_schemas JRubyInstance)
            (clojure.lang IFn)
            (java.util.concurrent TimeUnit)
@@ -249,12 +250,12 @@
 (schema/defn ^:always-validate
   lock-pool
   "Locks the JRuby pool for exclusive access."
-  [pool :- jruby-schemas/pool-queue-type
+  [pool-context :- jruby-schemas/PoolContext
    reason :- schema/Any
    event-callbacks :- [IFn]]
   (log/debug (i18n/trs "Acquiring lock on JRubyPool..."))
   (jruby-events/lock-requested event-callbacks reason)
-  (.lock pool)
+  (pool-protocol/lock pool-context)
   (jruby-events/lock-acquired event-callbacks reason)
   (log/debug (i18n/trs "Lock acquired")))
 
@@ -263,23 +264,23 @@
   "Locks the JRuby pool for exclusive access using a timeout in milliseconds.
   If the timeout is exceeded, a TimeoutException will be thrown and
   the pool will remain unlocked"
-  [pool :- jruby-schemas/pool-queue-type
+  [pool-context :- jruby-schemas/PoolContext
    timeout-ms :- schema/Int
    reason :- schema/Any
    event-callbacks :- [IFn]]
   (log/debug (i18n/trs "Acquiring lock on JRubyPool..."))
   (jruby-events/lock-requested event-callbacks reason)
-  (.lockWithTimeout pool timeout-ms TimeUnit/MILLISECONDS)
+  (pool-protocol/lock-with-timeout pool-context timeout-ms TimeUnit/MILLISECONDS)
   (jruby-events/lock-acquired event-callbacks reason)
   (log/debug (i18n/trs "Lock acquired")))
 
 (schema/defn ^:always-validate
   unlock-pool
   "Unlocks the JRuby pool, restoring concurernt access."
-  [pool :- jruby-schemas/pool-queue-type
+  [pool-context :- jruby-schemas/PoolContext
    reason :- schema/Any
    event-callbacks :- [IFn]]
-  (.unlock pool)
+  (pool-protocol/unlock pool-context)
   (jruby-events/lock-released event-callbacks reason)
   (log/debug (i18n/trs "Lock on JRubyPool released")))
 
@@ -341,26 +342,24 @@
 (defmacro with-lock
   "Acquires a lock on the pool, executes the body, and releases the lock."
   [pool-context reason & body]
-  `(let [pool# (get-pool ~pool-context)
-         event-callbacks# (get-event-callbacks ~pool-context)]
-     (lock-pool pool# ~reason event-callbacks#)
+  `(let [event-callbacks# (get-event-callbacks ~pool-context)]
+     (lock-pool ~pool-context ~reason event-callbacks#)
      (try
        ~@body
        (finally
-         (unlock-pool pool# ~reason event-callbacks#)))))
+         (unlock-pool ~pool-context ~reason event-callbacks#)))))
 
 (defmacro with-lock-with-timeout
   "Acquires a lock on the pool with a timeout in milliseconds,
   executes the body, and releases the lock. If the timeout is exceeded,
   a TimeoutException will be thrown"
   [pool-context timeout-ms reason & body]
-  `(let [pool# (get-pool ~pool-context)
-         event-callbacks# (get-event-callbacks ~pool-context)]
-     (lock-pool-with-timeout pool# ~timeout-ms ~reason event-callbacks#)
+  `(let [event-callbacks# (get-event-callbacks ~pool-context)]
+     (lock-pool-with-timeout ~pool-context ~timeout-ms ~reason event-callbacks#)
      (try
        ~@body
        (finally
-         (unlock-pool pool# ~reason event-callbacks#)))))
+         (unlock-pool ~pool-context ~reason event-callbacks#)))))
 
 (def jruby-version-info
   "Default version info string for jruby"

--- a/src/clj/puppetlabs/services/jruby_pool_manager/jruby_core.clj
+++ b/src/clj/puppetlabs/services/jruby_pool_manager/jruby_core.clj
@@ -71,7 +71,7 @@
   "Returns the number of JRubyInstances available in the pool."
   [pool :- jruby-schemas/pool-queue-type]
   {:post [(>= % 0)]}
-  (.size pool))
+  (.currentSize pool))
 
 (schema/defn ^:always-validate
   get-instance-state :- jruby-schemas/JRubyInstanceState

--- a/src/clj/puppetlabs/services/jruby_pool_manager/jruby_core.clj
+++ b/src/clj/puppetlabs/services/jruby_pool_manager/jruby_core.clj
@@ -200,7 +200,7 @@
    reason :- schema/Any
    event-callbacks :- [IFn]]
   (let [requested-event (jruby-events/instance-requested event-callbacks reason)
-        instance (jruby-internal/borrow-from-pool pool-context)]
+        instance (pool-protocol/borrow pool-context)]
     (jruby-events/instance-borrowed event-callbacks requested-event instance)
     instance))
 
@@ -219,7 +219,7 @@
    event-callbacks :- [IFn]]
   (let [timeout (get-in pool-context [:config :borrow-timeout])
         requested-event (jruby-events/instance-requested event-callbacks reason)
-        instance (jruby-internal/borrow-from-pool-with-timeout
+        instance (pool-protocol/borrow-with-timeout
                    pool-context
                    timeout)]
     (jruby-events/instance-borrowed event-callbacks requested-event instance)

--- a/src/clj/puppetlabs/services/jruby_pool_manager/jruby_schemas.clj
+++ b/src/clj/puppetlabs/services/jruby_pool_manager/jruby_schemas.clj
@@ -117,7 +117,8 @@
 
 (schema/defrecord ReferencePool
   [config :- JRubyConfig
-   internal :- PoolContextInternal])
+   internal :- PoolContextInternal
+   borrow-count :- Atom])
 
 (schema/defrecord InstancePool
   [config :- JRubyConfig

--- a/src/clj/puppetlabs/services/jruby_pool_manager/jruby_schemas.clj
+++ b/src/clj/puppetlabs/services/jruby_pool_manager/jruby_schemas.clj
@@ -3,8 +3,8 @@
   (:import (clojure.lang Atom Agent IFn PersistentArrayMap PersistentHashMap)
            (com.puppetlabs.jruby_utils.pool LockablePool)
            (org.jruby Main Main$Status RubyInstanceConfig)
-           (com.puppetlabs.jruby_utils.jruby ScriptingContainer)
-           (org.jruby.runtime Constants)))
+           (com.puppetlabs.jruby_utils.jruby ScriptingContainer)))
+
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Schemas
@@ -109,12 +109,23 @@
                      (nil? (schema/check PoolState @%)))
                'PoolStateContainer))
 
+(def PoolContextInternal
+  "The data structure that stores all JRuby pools"
+  {:modify-instance-agent JRubyPoolAgent
+   :pool-state PoolStateContainer
+   :event-callbacks Atom})
+
+(schema/defrecord ReferencePool
+  [config :- JRubyConfig
+   internal :- PoolContextInternal])
+
+(schema/defrecord InstancePool
+  [config :- JRubyConfig
+   internal :- PoolContextInternal])
+
 (def PoolContext
-  "The data structure that stores all JRuby pools and the original configuration."
-  {:config JRubyConfig
-   :internal {:modify-instance-agent JRubyPoolAgent
-              :pool-state PoolStateContainer
-              :event-callbacks Atom}})
+  (schema/pred #(or (instance? ReferencePool %)
+                    (instance? InstancePool %))))
 
 (def JRubyInstanceState
   "State metadata for an individual JRubyInstance"

--- a/src/clj/puppetlabs/services/jruby_pool_manager/jruby_schemas.clj
+++ b/src/clj/puppetlabs/services/jruby_pool_manager/jruby_schemas.clj
@@ -138,8 +138,7 @@
                'JRubyInstanceState))
 
 (def JRubyPuppetInstanceInternal
-  {:flush-instance-fn IFn
-   :pool pool-queue-type
+  {:pool pool-queue-type
    :initial-borrows (schema/maybe schema/Int)
    :max-borrows schema/Int
    :state JRubyInstanceStateContainer})

--- a/src/clj/puppetlabs/services/protocols/jruby_pool.clj
+++ b/src/clj/puppetlabs/services/protocols/jruby_pool.clj
@@ -20,4 +20,7 @@
     [this])
 
   (return
-    [this instance]))
+    [this instance])
+
+  (flush-pool
+    [this]))

--- a/src/clj/puppetlabs/services/protocols/jruby_pool.clj
+++ b/src/clj/puppetlabs/services/protocols/jruby_pool.clj
@@ -21,4 +21,3 @@
 
   (return
     [this instance]))
-

--- a/src/clj/puppetlabs/services/protocols/jruby_pool.clj
+++ b/src/clj/puppetlabs/services/protocols/jruby_pool.clj
@@ -17,7 +17,7 @@
     [this])
 
   (add-instance
-    [this instance])
+    [this id])
 
   (remove-instance
     [this instance])

--- a/src/clj/puppetlabs/services/protocols/jruby_pool.clj
+++ b/src/clj/puppetlabs/services/protocols/jruby_pool.clj
@@ -1,0 +1,27 @@
+(ns puppetlabs.services.protocols.jruby-pool)
+
+(defprotocol JRubyPool
+  (fill
+    [this])
+
+  (shutdown
+    [this])
+
+  (lock
+    [this])
+
+  (unlock
+    [this])
+
+  (add-instance
+    [this instance])
+
+  (remove-instance
+    [this instance])
+
+  (borrow
+    [this])
+
+  (return
+    [this instance]))
+

--- a/src/clj/puppetlabs/services/protocols/jruby_pool.clj
+++ b/src/clj/puppetlabs/services/protocols/jruby_pool.clj
@@ -10,6 +10,9 @@
   (lock
     [this])
 
+  (lock-with-timeout
+    [this timeout time-unit])
+
   (unlock
     [this])
 

--- a/src/clj/puppetlabs/services/protocols/jruby_pool.clj
+++ b/src/clj/puppetlabs/services/protocols/jruby_pool.clj
@@ -19,6 +19,9 @@
   (borrow
     [this])
 
+  (borrow-with-timeout
+    [this timeout])
+
   (return
     [this instance])
 

--- a/src/clj/puppetlabs/services/protocols/jruby_pool.clj
+++ b/src/clj/puppetlabs/services/protocols/jruby_pool.clj
@@ -2,28 +2,48 @@
 
 (defprotocol JRubyPool
   (fill
-    [this])
+    [pool-context]
+    "Creates all the necessary JRuby instances and adds them to the pool.")
 
   (shutdown
-    [this])
+    [pool-context]
+    "Shuts down the JRuby pool, inserting a poison pill to prevent further borrows and terminating
+     all JRuby instances.")
 
   (lock
-    [this])
+    [pool-context]
+    "Blocks waiting for all currently held JRubies to be returned to the pool, preventing further
+    borrows until the pool is unlocked.")
 
   (lock-with-timeout
-    [this timeout time-unit])
+    [pool-context timeout time-unit]
+    "Attempts to lock the JRuby pool, timing out if the supplied interval has elapsed.")
 
   (unlock
-    [this])
+    [pool-context]
+    "Unlocks the JRuby pool, allowing borrows to proceed.")
 
   (borrow
-    [this])
+    [pool-context]
+    "Returns a reference to a JRuby instance. Will block if the pool is locked or no instances
+    are available.")
+
 
   (borrow-with-timeout
-    [this timeout])
+    [pool-context timeout]
+    "Returns a reference to a JRuby instance. Will block if the pool is locked or no instances
+    are available, timing out when the supplied number of milliseconds has elapsed.")
 
   (return
-    [this instance])
+    [pool-context instance]
+    "Releases a held reference to a JRuby instance back to the pool. If `max-requests-per-instance`
+    is configured and has been reached for this instance, this function will trigger a flush of
+    the instance. Note that when using the ReferencePool, this will also cause the pool to be locked.
+
+    If something besides a JRuby instance is passed to return (e.g. a Pill), this function is a no-op.")
 
   (flush-pool
-    [this]))
+    [pool-context]
+    "Removes and terminates all the JRuby instances from the pool, then creates new ones and adds
+    them to the pool. Note that when using the ReferencePool, this will cause the pool to be locked,
+    with a timeout equal to the configured `flush-timeout`."))

--- a/src/clj/puppetlabs/services/protocols/jruby_pool.clj
+++ b/src/clj/puppetlabs/services/protocols/jruby_pool.clj
@@ -16,12 +16,6 @@
   (unlock
     [this])
 
-  (add-instance
-    [this id])
-
-  (remove-instance
-    [this instance])
-
   (borrow
     [this])
 

--- a/src/java/com/puppetlabs/jruby_utils/pool/JRubyPool.java
+++ b/src/java/com/puppetlabs/jruby_utils/pool/JRubyPool.java
@@ -296,7 +296,7 @@ public final class JRubyPool<E> implements LockablePool<E> {
     }
 
     @Override
-    public int size() {
+    public int currentSize() {
         int size;
         final ReentrantLock lock = this.queueLock;
         lock.lock();

--- a/src/java/com/puppetlabs/jruby_utils/pool/LockablePool.java
+++ b/src/java/com/puppetlabs/jruby_utils/pool/LockablePool.java
@@ -27,8 +27,11 @@ public interface LockablePool<E> {
      * {@link #getRegisteredElements()}.
      *
      * @param e the element to remove from the list of registered elements
+     * @throws InterruptedException if the calling thread is interrupted while
+     *                              it waits for all instances to be returned
+     *                              to the pool
      */
-    void unregister(E e);
+    void unregister(E e) throws InterruptedException;
 
     /**
      * Borrow an element from the pool.  This method will block until
@@ -104,7 +107,7 @@ public interface LockablePool<E> {
      * have been borrowed but not yet returned to the pool at the time this
      * method is called will remain registered.
      */
-    void clear();
+    void clear() throws InterruptedException;
 
     /**
      * Returns the number of elements that can be added into the pool.  Equal

--- a/src/java/com/puppetlabs/jruby_utils/pool/LockablePool.java
+++ b/src/java/com/puppetlabs/jruby_utils/pool/LockablePool.java
@@ -120,7 +120,7 @@ public interface LockablePool<E> {
      * Returns the number of elements that have been registered with but not
      * borrowed from the pool.
      */
-    int size();
+    int currentSize();
 
    /**
     * Lock the pool. This method should make the following guarantees:

--- a/src/java/com/puppetlabs/jruby_utils/pool/ReferencePool.java
+++ b/src/java/com/puppetlabs/jruby_utils/pool/ReferencePool.java
@@ -174,7 +174,6 @@ public final class ReferencePool<E> implements LockablePool<E> {
                 } else {
                     item = this.instance;
                     this.currentBorrowCount.getAndIncrement();
-                    LOGGER.info("Borrowing, count is " + currentBorrowCount.get());
                 }
             } while (item == null);
         } finally {
@@ -230,7 +229,6 @@ public final class ReferencePool<E> implements LockablePool<E> {
                 } else if (instance != null) {
                     item = instance;
                     this.currentBorrowCount.getAndIncrement();
-                    LOGGER.info("Borrowing, count is " + currentBorrowCount.get());
                 }
             } while (item == null);
         } finally {

--- a/src/java/com/puppetlabs/jruby_utils/pool/ReferencePool.java
+++ b/src/java/com/puppetlabs/jruby_utils/pool/ReferencePool.java
@@ -309,7 +309,7 @@ public final class ReferencePool<E> implements LockablePool<E> {
     }
 
     @Override
-    public int size() {
+    public int currentSize() {
         int size;
         final ReentrantLock lock = this.borrowLock;
         lock.lock();

--- a/src/java/com/puppetlabs/jruby_utils/pool/ReferencePool.java
+++ b/src/java/com/puppetlabs/jruby_utils/pool/ReferencePool.java
@@ -131,7 +131,7 @@ public final class ReferencePool<E> implements LockablePool<E> {
      * Unregisters the JRuby instance. Blocks waiting for all borrows of the
      * instance to be returned before clearing it out. In this pool implementation,
      * `clear` and `unregister` are aliases of one another, since clearing the pool
-     * is the same as clearing the on active instance.
+     * is the same as clearing the one active instance.
      *
      * @param e the instance to clean up
      * @throws InterruptedException
@@ -294,12 +294,13 @@ public final class ReferencePool<E> implements LockablePool<E> {
     }
 
     /**
-     * Alias for unregister in this implementation. Blocks waiting for
-     * all references to be returned to the pool.
+     * Reduce max borrow count down to the number of currently borrowed instances.
+     * Used when shutting down to help prevent additional borrows of the instance,
+     * in preparation for unregistering it.
      */
     @Override
-    public void clear() throws InterruptedException {
-        unregister(instance);
+    public void clear() {
+        this.maxBorrowCount = this.currentBorrowCount.get();
     }
 
     @Override

--- a/src/java/com/puppetlabs/jruby_utils/pool/ReferencePool.java
+++ b/src/java/com/puppetlabs/jruby_utils/pool/ReferencePool.java
@@ -299,8 +299,8 @@ public final class ReferencePool<E> implements LockablePool<E> {
      * in preparation for unregistering it.
      */
     @Override
-    public void clear() {
-        this.maxBorrowCount = this.currentBorrowCount.get();
+    public void clear() throws InterruptedException {
+        unregister(this.instance);
     }
 
     @Override

--- a/src/java/com/puppetlabs/jruby_utils/pool/ReferencePool.java
+++ b/src/java/com/puppetlabs/jruby_utils/pool/ReferencePool.java
@@ -1,0 +1,526 @@
+package com.puppetlabs.jruby_utils.pool;
+
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.ReentrantLock;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * An implementation of LockablePool for managing a pool of JRubyInstances.
+ *
+ * @param <E> the type of element that can be added to the pool.
+ */
+public final class ReferencePool<E> implements LockablePool<E> {
+    private static final Logger LOGGER = LoggerFactory.getLogger(
+            ReferencePool.class);
+
+    // The `LockingPool` contract requires some synchronization behaviors that
+    // are not natively present in any of the JDK deque implementations -
+    // specifically to allow one calling thread to call lock() to supercede
+    // and hold off any pending pool borrowers until unlock() is called.
+    // This class implementation fulfills the contract by managing the
+    // synchronization constructs directly rather than deferring to an
+    // underlying JDK data structure to manage concurrent access.
+    //
+    // This implementation is modeled somewhat off of what the
+    // `LinkedBlockingDeque` class in the OpenJDK does to manage
+    // concurrency.  It uses a single `ReentrantLock` to provide mutual
+    // exclusion around offer and take requests, with condition variables
+    // used to park and later reawaken requests as needed, e.g., when pool
+    // items are unavailable for borrowing or when the pool lock is
+    // unavailable.
+    //
+    // See http://hg.openjdk.java.net/jdk8/jdk8/jdk/file/687fd7c7986d/src/share/classes/java/util/concurrent/LinkedBlockingDeque.java#l157
+
+    // Lock which guards all accesses to the underlying instance.
+    // Constructed as "nonfair" for performance, like the lock that a
+    // `LinkedBlockingDeque` does.  Not clear that we need this
+    // to be a "fair" lock.
+    private final ReentrantLock borrowLock = new ReentrantLock(false);
+
+    // Condition signaled when all borrowed references have been
+    // handed back or if a pill has been inserted.  Awaited when a
+    // lock has been requested but one or more references have been
+    // borrowed from the pool.
+    private final Condition lockAvailable = borrowLock.newCondition();
+
+    // Condition signaled when an element has been added into the queue.
+    // Awaited when a request has been made to borrow an item but no elements
+    // currently exist in the queue.
+    private final Condition borrowsAvailable = borrowLock.newCondition();
+
+    // Condition signaled when the pool has been unlocked.  Awaited when a
+    // request has been made to borrow an reference or lock the pool but the pool
+    // is currently locked.
+    private final Condition poolNotLocked = borrowLock.newCondition();
+
+    // Condition signaled when all borrowed references have been returned
+    // to the pool. Awaited when we are preparing to delete the instance
+    // and need to make sure it is not in use.
+    private final Condition instanceNotBorrowed = borrowLock.newCondition();
+
+    // The JRuby instance that this pool hands out references to
+    private volatile E instance;
+
+    // How many times the JRuby instance can be borrowed at once
+    private int maxBorrowCount;
+
+    // Current number of references to the pool held out in the world.
+    // Updates to this need to be visible to all threads.
+    private volatile AtomicInteger currentBorrowCount;
+
+    // Thread which currently holds the pool lock.  null indicates that
+    // there is no current pool lock holder.  Using the current Thread
+    // object for tracking the pool lock owner is comparable to what the JDK's
+    // `ReentrantLock` class does via the `AbstractOwnableSynchronizer` class:
+    //
+    // http://hg.openjdk.java.net/jdk8/jdk8/jdk/file/687fd7c7986d/src/share/classes/java/util/concurrent/locks/ReentrantLock.java#l164
+    // http://hg.openjdk.java.net/jdk8/jdk8/jdk/file/687fd7c7986d/src/share/classes/java/util/concurrent/locks/AbstractOwnableSynchronizer.java#l64
+    //
+    // Unlike the `AbstractOwnableSynchronizer` class implementation, we marked
+    // this variable as `volatile` because we couldn't convince ourselves
+    // that it would be safe to update this variable from different threads and
+    // not be susceptible to per-thread / per-CPU caching causing the wrong
+    // value to be seen by a thread.  `volatile` seems safer and doesn't appear
+    // to impose any noticeable performance degradation.
+    private volatile Thread poolLockThread = null;
+
+    // Holds a poison pill object for errors and shutdowns
+    // If not null, takes priority over any pool instance when a call to
+    // borrowItem is made. Returns made using releaseItem are ignored if the
+    // released item is the poison pill already stored here
+    private volatile E pill;
+
+    /**
+     * Create a "pool" of handles to a Jruby instance.
+     *
+     * @param maxBorrows the max number of instance refs that can be handed out
+     */
+    public ReferencePool(int maxBorrows) {
+        this.instance = null;
+        this.maxBorrowCount = maxBorrows;
+        this.currentBorrowCount = new AtomicInteger(0);
+    }
+
+    @Override
+    public void register(E e) {
+        final ReentrantLock lock = this.borrowLock;
+        lock.lock();
+        try {
+            if (instance != null) {
+                throw new IllegalStateException(
+                        "Unable to register additional instance, pool full");
+            }
+
+            instance = e;
+            currentBorrowCount.set(0);
+
+            signalPoolNotEmpty();
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * Unregisters the JRuby instance. Blocks waiting for all borrows of the
+     * instance to be returned before clearing it out. In this pool implementation,
+     * `clear` and `unregister` are aliases of one another, since clearing the pool
+     * is the same as clearing the on active instance.
+     *
+     * @param e the instance to clean up
+     * @throws InterruptedException
+     */
+    @Override
+    public void unregister(E e) throws InterruptedException {
+        final ReentrantLock lock = this.borrowLock;
+        lock.lock();
+        try {
+            if (currentBorrowCount.get() != 0) {
+                instanceNotBorrowed.await();
+            }
+            instance = null;
+
+            signalIfLockCanProceed();
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    @Override
+    public E borrowItem() throws InterruptedException {
+        E item = null;
+        final ReentrantLock lock = this.borrowLock;
+        lock.lock();
+        try {
+            final Thread currentThread = Thread.currentThread();
+            do {
+                if (this.pill != null) {
+                    // Return the pill immediately if there is one
+                    item = pill;
+                } else if (isPoolLockHeldByAnotherThread(currentThread)) {
+                    poolNotLocked.await();
+                } else if (instance == null) {
+                    // No instance initialized yet
+                    borrowsAvailable.await();
+                } else if (this.currentBorrowCount.get() >= this.maxBorrowCount) {
+                    // Max borrow count reached, wait for one to be returned
+                    borrowsAvailable.await();
+                } else {
+                    item = this.instance;
+                    this.currentBorrowCount.getAndIncrement();
+                    LOGGER.info("Borrowing, count is " + currentBorrowCount.get());
+                }
+            } while (item == null);
+        } finally {
+            lock.unlock();
+        }
+
+        return item;
+    }
+
+    @Override
+    public E borrowItemWithTimeout(long timeout, TimeUnit unit) throws
+            InterruptedException {
+        E item = null;
+        final ReentrantLock lock = this.borrowLock;
+        long remainingMaxTimeToWait = unit.toNanos(timeout);
+
+        // `borrowLock.lockInterruptibly()` is called here as opposed to just
+        // `borrowLock.borrowLock` to follow the pattern that the JDK's
+        // `LinkedBlockingDeque` does for a timed poll from a deque.  See:
+        // http://hg.openjdk.java.net/jdk8/jdk8/jdk/file/687fd7c7986d/src/share/classes/java/util/concurrent/LinkedBlockingDeque.java#l516
+        lock.lockInterruptibly();
+        try {
+            final Thread currentThread = Thread.currentThread();
+            // This pattern of using timed `awaitNanos` on a condition
+            // variable to track the total time spent waiting for an item to
+            // be available to be borrowed follows the logic that the JDK's
+            // `LinkedBlockingDeque` in `pollFirst` uses.  See:
+            // http://hg.openjdk.java.net/jdk8/jdk8/jdk/file/687fd7c7986d/src/share/classes/java/util/concurrent/LinkedBlockingDeque.java#l522
+            do {
+                if (this.pill != null) {
+                    // Return the pill immediately if there is one
+                    item = pill;
+                } else if (isPoolLockHeldByAnotherThread(currentThread)) {
+                    if (remainingMaxTimeToWait <= 0) {
+                        break;
+                    }
+                    remainingMaxTimeToWait =
+                            poolNotLocked.awaitNanos(remainingMaxTimeToWait);
+                } else if (this.instance == null) {
+                    // No instance initialized yet
+                    if (remainingMaxTimeToWait <= 0) {
+                        break;
+                    }
+                    remainingMaxTimeToWait =
+                            borrowsAvailable.awaitNanos(remainingMaxTimeToWait);
+                } else if (this.currentBorrowCount.get() >= this.maxBorrowCount) {
+                    // Max borrow count reached, wait for one to be returned
+                    if (remainingMaxTimeToWait <= 0) {
+                        break;
+                    }
+                    remainingMaxTimeToWait =
+                            borrowsAvailable.awaitNanos(remainingMaxTimeToWait);
+                } else if (instance != null) {
+                    item = instance;
+                    this.currentBorrowCount.getAndIncrement();
+                    LOGGER.info("Borrowing, count is " + currentBorrowCount.get());
+                }
+            } while (item == null);
+        } finally {
+            lock.unlock();
+        }
+
+        return item;
+    }
+
+    /**
+     * Release an item and return it to the pool. Does nothing if the item
+     * being released is the pill.
+     * Throws an `IllegalArgumentException` if the item is not currently
+     * registered by the pool and the item is not the pill, if one has been
+     * inserted
+     */
+    @Override
+    public void releaseItem(E e) {
+        final ReentrantLock lock = this.borrowLock;
+        lock.lock();
+        try {
+            if (e != this.pill) {
+                if (!isRegistered(e)) {
+                    String errorMsg = "The item being released is not registered with the pool";
+                    throw new IllegalArgumentException(errorMsg);
+                }
+
+                this.currentBorrowCount.getAndDecrement();
+                signalPoolNotEmpty();
+
+                if (currentBorrowCount.get() == 0) {
+                   instanceNotBorrowed.signal();
+                }
+            }
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    private boolean isRegistered(E e) {
+        return instance.equals(e);
+    }
+
+    /**
+     * Insert a poison pill into the pool.  It should only ever be used to
+     * insert a `PoisonPill` or `ShutdownPoisonPill` to the pool. Only the
+     * first call will insert a pill. Subsequent insertions will be ignored
+     */
+    @Override
+    public void insertPill(E e) {
+        final ReentrantLock lock = this.borrowLock;
+        lock.lock();
+        try {
+            if (this.pill == null) {
+                this.pill = e;
+                signalPoolNotEmpty();
+            }
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * Alias for unregister in this implementation. Blocks waiting for
+     * all references to be returned to the pool.
+     */
+    @Override
+    public void clear() throws InterruptedException {
+        unregister(instance);
+    }
+
+    @Override
+    public int remainingCapacity() {
+        return instance == null ? 1 : 0;
+    }
+
+    @Override
+    public int size() {
+        int size;
+        final ReentrantLock lock = this.borrowLock;
+        lock.lock();
+        try {
+            if (instance == null) {
+                size = 0;
+            } else {
+                size = this.maxBorrowCount - this.currentBorrowCount.get();
+            }
+        } finally {
+            lock.unlock();
+        }
+        return size;
+    }
+
+    /**
+     * Lock the pool. Blocks until the lock is granted and the pool has been filled
+     * back up to its full capacity
+     * @throws InterruptedException
+     */
+    @Override
+    public void lock() throws InterruptedException {
+        final ReentrantLock lock = this.borrowLock;
+        lock.lock();
+        try {
+            String pillErrorMsg = "Lock can't be granted because a pill has been inserted";
+
+            final Thread currentThread = Thread.currentThread();
+            while (!isPoolLockHeldByCurrentThread(currentThread)) {
+                if (this.pill != null) {
+                    throw new InterruptedException(pillErrorMsg);
+                }
+                if (!isPoolLockHeld()) {
+                    poolLockThread = currentThread;
+                } else {
+                    poolNotLocked.await();
+                }
+            }
+            try {
+                // Wait until all references have been returned to the pool
+                while (this.currentBorrowCount.get() > 0) {
+                    lockAvailable.await();
+                    if (this.pill != null) {
+                        throw new InterruptedException(pillErrorMsg);
+                    }
+                }
+            } catch (Exception e) {
+                freePoolLock();
+                throw e;
+            }
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    @Override
+    public void lockWithTimeout(long timeout, TimeUnit unit) throws InterruptedException, TimeoutException {
+        final ReentrantLock lock = this.borrowLock;
+        long remainingMaxTimeToWait = unit.toNanos(timeout);
+
+        // `borrowLock.lockInterruptibly()` is called here as opposed to just
+        // `borrowLock.borrowLock` to follow the pattern that the JDK's
+        // `LinkedBlockingDeque` does for a timed poll from a deque.  See:
+        // http://hg.openjdk.java.net/jdk8/jdk8/jdk/file/687fd7c7986d/src/share/classes/java/util/concurrent/LinkedBlockingDeque.java#l516
+        lock.lockInterruptibly();
+        try {
+            String pillErrorMsg = "Lock can't be granted because a pill has been inserted";
+            String timeoutErrorMsg = "Timeout limit reached before lock could be granted";
+
+            final Thread currentThread = Thread.currentThread();
+            while (!isPoolLockHeldByCurrentThread(currentThread)) {
+                if (this.pill != null) {
+                    throw new InterruptedException(pillErrorMsg);
+                }
+
+                if (!isPoolLockHeld()) {
+                    poolLockThread = currentThread;
+                } else {
+                    if (remainingMaxTimeToWait <= 0) {
+                        throw new TimeoutException(timeoutErrorMsg);
+                    }
+                    remainingMaxTimeToWait = poolNotLocked.awaitNanos(remainingMaxTimeToWait);
+                }
+            }
+
+            try {
+                // Wait until all references have been returned to the pool
+                while (this.currentBorrowCount.get() > 0) {
+                    if (remainingMaxTimeToWait <= 0) {
+                        throw new TimeoutException(timeoutErrorMsg);
+                    }
+                    remainingMaxTimeToWait = lockAvailable.awaitNanos(remainingMaxTimeToWait);
+
+                    if (this.pill != null) {
+                        throw new InterruptedException(pillErrorMsg);
+                    }
+                }
+            } catch (Exception e) {
+                freePoolLock();
+                throw e;
+            }
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    @Override
+    public boolean isLocked() {
+        boolean locked;
+        final ReentrantLock lock = this.borrowLock;
+        lock.lock();
+        try {
+            locked = isPoolLockHeld();
+        } finally {
+            lock.unlock();
+        }
+        return locked;
+    }
+
+    @Override
+    public void unlock() {
+        final ReentrantLock lock = this.borrowLock;
+        lock.lock();
+        try {
+            final Thread currentThread = Thread.currentThread();
+            if (!isPoolLockHeldByCurrentThread(currentThread)) {
+                String lockErrorMessage;
+                if (isPoolLockHeldByAnotherThread(currentThread)) {
+                    lockErrorMessage = "held by " + poolLockThread;
+                } else {
+                    lockErrorMessage = "not held by any thread";
+                }
+                throw new IllegalStateException(
+                        "Unlock requested from thread not holding the lock.  " +
+                        "Requested from " +
+                        currentThread +
+                        " but lock " +
+                        lockErrorMessage +
+                        ".");
+            }
+            freePoolLock();
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    public Set<E> getRegisteredElements() {
+      Set<E> registered = new CopyOnWriteArraySet<E>();
+      if (instance != null) {
+          registered.add(instance);
+      }
+      return registered;
+    }
+
+    private void freePoolLock() {
+        poolLockThread = null;
+        // Need to use 'signalAll' here because there might be multiple
+        // waiters (e.g., multiple borrowers) queued up, waiting for the
+        // pool to be unlocked.
+        poolNotLocked.signalAll();
+        // Borrowers that are woken up when an instance is returned to the
+        // pool and the pool borrowLock is held would then start waiting on a
+        // 'poolNotLocked' signal instead.  Re-signalling 'borrowsAvailable' here
+        // allows any borrowers still waiting on the 'borrowsAvailable' signal to be
+        // reawoken when the pool lock is released, compensating for any
+        // 'borrowsAvailable' signals that might have been essentially ignored from
+        // when the pool lock was held.
+        if (this.currentBorrowCount.get() < this.maxBorrowCount) {
+            borrowsAvailable.signalAll();
+        }
+    }
+
+    /**
+     * Should be called if the pool is no longer empty (or a pill is inserted),
+     * so that threads waiting for pool instances can be woken up
+     */
+    private void signalPoolNotEmpty() {
+        // Could use 'signalAll' here instead of 'signal' but 'signal' is
+        // less expensive in that only one waiter will be woken up.  Can use
+        // signal here because the thread being awoken will be able to borrow
+        // a pool instance and any further waiters will be woken up by
+        // subsequent posts of this signal when instances are added/returned to
+        // the queue.
+        borrowsAvailable.signal();
+        signalIfLockCanProceed();
+    }
+
+    /**
+     * Checks if threads waiting on the pool lock should be woken up.
+     * This will wake them up if either all borrowed references have
+     * been returned to the pool, or if a pill has been inserted
+     */
+    private void signalIfLockCanProceed() {
+        // Could use 'signalAll' here instead of 'signal'.  Doesn't really
+        // matter though in that there will only be one waiter at most which
+        // is active at a time - a caller of lock() that has just acquired
+        // the pool lock but is waiting for the live queue to be completely
+        // filled
+        if ((instance != null && currentBorrowCount.get() == 0) || pill != null) {
+            lockAvailable.signal();
+        }
+    }
+
+    private boolean isPoolLockHeld() {
+        return poolLockThread != null;
+    }
+
+    private boolean isPoolLockHeldByCurrentThread(Thread currentThread) {
+        return poolLockThread == currentThread;
+    }
+
+    private boolean isPoolLockHeldByAnotherThread(Thread currentThread) {
+        return (poolLockThread != null) && (poolLockThread != currentThread);
+    }
+}

--- a/test/integration/puppetlabs/services/jruby_pool_manager/jruby_internal_test.clj
+++ b/test/integration/puppetlabs/services/jruby_pool_manager/jruby_internal_test.clj
@@ -44,13 +44,13 @@
                    {:compile-mode :jit
                     :profiler-output-file profiler-file
                     :profiling-mode :flat}))
-          instance (jruby-internal/create-pool-instance! pool 0 config #())
-          instance-two (jruby-internal/create-pool-instance! pool 1 config #())
+          instance (jruby-internal/create-pool-instance! pool 0 config)
+          instance-two (jruby-internal/create-pool-instance! pool 1 config)
           container (:scripting-container instance)
           container-two (:scripting-container instance-two)]
       (try
         (is (= RubyInstanceConfig$CompileMode/JIT
-            (.getCompileMode container)))
+              (.getCompileMode container)))
         (is (= RubyInstanceConfig$ProfilingMode/FLAT
                (.getProfilingMode container)))
         (finally
@@ -70,7 +70,7 @@
     (let [pool (JRubyPool. 1)
           config (logutils/with-test-logging
                   (jruby-testutils/jruby-config {}))
-          instance (jruby-internal/create-pool-instance! pool 0 config #())
+          instance (jruby-internal/create-pool-instance! pool 0 config)
           container (:scripting-container instance)]
       (try
         (is (= RubyInstanceConfig$CompileMode/JIT
@@ -84,7 +84,7 @@
     (let [pool (JRubyPool. 1)
           config (logutils/with-test-logging
                   (jruby-testutils/jruby-config {}))
-          instance (jruby-internal/create-pool-instance! pool 0 config #())
+          instance (jruby-internal/create-pool-instance! pool 0 config)
           result (jruby-internal/get-instance-thread-dump instance)]
       (is (some? (:error result)))
       (is (re-find #"JRuby management interface not enabled" (:error result)))))
@@ -93,7 +93,7 @@
     (let [pool (JRubyPool. 1)
           config (logutils/with-test-logging
                   (jruby-testutils/jruby-config {}))
-          instance (jruby-internal/create-pool-instance! pool 0 config #())
+          instance (jruby-internal/create-pool-instance! pool 0 config)
           _ (-> (:scripting-container instance)
                 (.runScriptlet (StringReader.
                                 "def naptime
@@ -110,7 +110,7 @@
     (let [pool (JRubyPool. 1)
           config (logutils/with-test-logging
                   (jruby-testutils/jruby-config {}))
-          instance (jruby-internal/create-pool-instance! pool 0 config #())
+          instance (jruby-internal/create-pool-instance! pool 0 config)
           mbean-name (jruby-internal/jmx-bean-name instance "Runtime")
           _ (jmx/unregister-mbean mbean-name)
           failing-mbean (proxy [org.jruby.management.Runtime]

--- a/test/integration/puppetlabs/services/jruby_pool_manager/jruby_locking_test.clj
+++ b/test/integration/puppetlabs/services/jruby_pool_manager/jruby_locking_test.clj
@@ -17,7 +17,7 @@
   @(future
     (if-let [instance (jruby-core/borrow-from-pool-with-timeout pool-context :test [])]
       (do
-        (jruby-core/return-to-pool instance :test [])
+        (jruby-core/return-to-pool pool-context instance :test [])
         true))))
 
 (deftest ^:integration with-lock-test
@@ -105,7 +105,7 @@
        (testing "lock not granted yet when instance still borrowed"
          (is (not (realized?
                    lock-acquired?))))
-       (jruby-core/return-to-pool instance :with-lock-and-borrow-contention-test [])
+       (jruby-core/return-to-pool pool-context instance :with-lock-and-borrow-contention-test [])
        @lock-acquired?
        (testing "cannot borrow from non-locking thread when locked"
          (is (not (can-borrow-from-different-thread? pool-context))))
@@ -152,6 +152,6 @@
                (is false))))
          (is (not (.isLocked pool)))
          (finally
-           (jruby-core/return-to-pool borrowed-instance
+           (jruby-core/return-to-pool pool-context borrowed-instance
                                       :lock-timeout-exceeded-test
                                       [])))))))

--- a/test/integration/puppetlabs/services/jruby_pool_manager/jruby_pool_int_test.clj
+++ b/test/integration/puppetlabs/services/jruby_pool_manager/jruby_pool_int_test.clj
@@ -144,11 +144,11 @@
            pool (:pool pool-state)]
        ;; wait for all jrubies to be added to the pool
        (jruby-testutils/wait-for-jrubies-from-pool-context pool-context)
-       (is (= 4 (.size (jruby-core/get-pool pool-context))))
+       (is (= 4 (.currentSize (jruby-core/get-pool pool-context))))
        (jruby-core/flush-pool-for-shutdown! pool-context)
 
        ;; flushing the pool should remove all JRubyInstances
-       (is (= 0 (.size pool)))
+       (is (= 0 (.currentSize pool)))
        ;; any borrows should now return shutdown poison pill
        (is (jruby-schemas/shutdown-poison-pill? (.borrowItem pool)))))))
 

--- a/test/integration/puppetlabs/services/jruby_pool_manager/jruby_pool_int_test.clj
+++ b/test/integration/puppetlabs/services/jruby_pool_manager/jruby_pool_int_test.clj
@@ -100,7 +100,7 @@
                      [])
            loop-count 0]
       (let [borrow-count (:borrow-count (jruby-core/get-instance-state instance))]
-        (jruby-core/return-to-pool instance :borrow-until-desired-borrow-count [])
+        (jruby-core/return-to-pool pool-context instance :borrow-until-desired-borrow-count [])
         (cond
           (= (inc borrow-count) desired-borrow-count) true
           (= loop-count max-borrow-wait-count) false
@@ -178,14 +178,14 @@
          (borrow-until-desired-borrow-count pool-context 9)
          (let [instance-to-flush (jruby-core/borrow-from-pool pool-context :instance-to-flush [])]
            (is (= 9 (:borrow-count (jruby-core/get-instance-state instance-to-flush))))
-           (jruby-core/return-to-pool instance-to-flush :instance-to-flush []))
+           (jruby-core/return-to-pool pool-context instance-to-flush :instance-to-flush []))
 
          (is (nil? (.runScriptlet sc "$unique_file.close"))
              "Unexpected response on attempt to close unique file")
          (finally
            (.runScriptlet sc "$unique_file.unlink")))
        ;; return the instance
-       (jruby-core/return-to-pool instance :hold-file-handle-while-another-instance-is-flushed [])
+       (jruby-core/return-to-pool pool-context instance :hold-file-handle-while-another-instance-is-flushed [])
        ;; Show that the instance-to-flush instance did actually get flushed
        (check-jrubies-for-constant-counts pool-context 3 1)))))
 
@@ -232,14 +232,14 @@
 
              ;; now we're going to return instance2 to the pool.  This should cause it
              ;; to get flushed. The main pool flush operation is still blocked.
-             (jruby-core/return-to-pool instance2
+             (jruby-core/return-to-pool pool-context instance2
                                         :max-borrows-flush-while-pool-flush-in-progress-test
                                         [])
              ;; Wait until instance2 is returned
              (is (jruby-testutils/wait-for-instances pool 3) "Timed out waiting for instance2 to return to pool")
 
              ;; and finally, we return the last instance we borrowed to the pool
-             (jruby-core/return-to-pool instance1
+             (jruby-core/return-to-pool pool-context instance1
                                         :max-borrows-flush-while-pool-flush-in-progress-test
                                         [])
 
@@ -279,7 +279,7 @@
                        :initialization-and-cleanup-hooks-test
                        [])]
          (is (= "FOO" (deref (:foo instance))))
-         (jruby-core/return-to-pool instance :initialization-and-cleanup-hooks-test [])
+         (jruby-core/return-to-pool pool-context instance :initialization-and-cleanup-hooks-test [])
 
          (jruby-core/flush-pool! pool-context)
          ; wait until the flush is complete
@@ -310,6 +310,7 @@
          (.remove jruby-env "RUBY")
          (is (= {"CUSTOMENV" "foobar"} jruby-env))
          (jruby-core/return-to-pool
-          instance
-          :initialize-environment-variables-test
-          []))))))
+           pool-context
+           instance
+           :initialize-environment-variables-test
+           []))))))

--- a/test/unit/puppetlabs/jruby_utils/lockable_pool_test.clj
+++ b/test/unit/puppetlabs/jruby_utils/lockable_pool_test.clj
@@ -348,9 +348,9 @@
   (testing "releaseItem returns item to pool and allows pool to still be lockable"
     (let [pool (create-populated-pool 2)
           instance (.borrowItem pool)]
-      (is (= 1 (.size pool)))
+      (is (= 1 (.currentSize pool)))
       (.releaseItem pool instance)
-      (is (= 2 (.size pool)))
+      (is (= 2 (.currentSize pool)))
       (is (not (.isLocked pool)))
       (.lock pool)
       (is (.isLocked pool))
@@ -556,7 +556,7 @@
           pill (str "I'm just a pill, yes I'm only a pill")
           instance (.borrowItem pool)
           blocked-borrow (future (.borrowItem pool))]
-      (is (= 0 (.size pool)))
+      (is (= 0 (.currentSize pool)))
 
       ; Give future a chance to run and block
       (Thread/sleep 500)
@@ -637,10 +637,10 @@
                 "registered elements")
     (let [pool (create-populated-pool 3)
           instance (.borrowItem pool)]
-      (is (= 2 (.size pool)))
+      (is (= 2 (.currentSize pool)))
       (is (= 3 (.. pool getRegisteredElements size)))
       (.clear pool)
-      (is (= 0 (.size pool)))
+      (is (= 0 (.currentSize pool)))
       (let [registered-elements (.getRegisteredElements pool)]
         (is (= 1 (.size registered-elements)))
         (is (identical? instance (-> registered-elements

--- a/test/unit/puppetlabs/jruby_utils/lockable_ref_pool_test.clj
+++ b/test/unit/puppetlabs/jruby_utils/lockable_ref_pool_test.clj
@@ -332,9 +332,9 @@
   (testing "releaseItem returns item to pool and allows pool to still be lockable"
     (let [pool (create-populated-pool 2)
           instance (.borrowItem pool)]
-      (is (= 1 (.size pool)))
+      (is (= 1 (.currentSize pool)))
       (.releaseItem pool instance)
-      (is (= 2 (.size pool)))
+      (is (= 2 (.currentSize pool)))
       (is (not (.isLocked pool)))
       (.lock pool)
       (is (.isLocked pool))
@@ -540,7 +540,7 @@
           pill (str "I'm just a pill, yes I'm only a pill")
           _ (.borrowItem pool)
           blocked-borrow (future (.borrowItem pool))]
-      (is (= 0 (.size pool)))
+      (is (= 0 (.currentSize pool)))
 
       ; Give future a chance to run and block
       (Thread/sleep 500)
@@ -624,11 +624,11 @@
           _ (future
               (.clear pool)
               (deliver cleared? true))]
-      (is (= 1 (.size pool)))
+      (is (= 1 (.currentSize pool)))
       (is (= false (realized? cleared?)))
       (.releaseItem pool instance)
       (is (= true @cleared?))
-      (is (= 0 (.size pool))))))
+      (is (= 0 (.currentSize pool))))))
 
 (deftest pool-remaining-capacity
   (testing "remaining capacity in pool correct per instances registered"

--- a/test/unit/puppetlabs/jruby_utils/lockable_ref_pool_test.clj
+++ b/test/unit/puppetlabs/jruby_utils/lockable_ref_pool_test.clj
@@ -616,20 +616,6 @@
           (is (= "Lock can't be granted because a pill has been inserted"
                  (.getMessage exception))))))))
 
-(deftest pool-clear-test
-  (testing (str "clear blocks waiting for all references to be returned")
-    (let [pool (create-populated-pool 2)
-          instance (.borrowItem pool)
-          cleared? (promise)
-          _ (future
-              (.clear pool)
-              (deliver cleared? true))]
-      (is (= 1 (.currentSize pool)))
-      (is (= false (realized? cleared?)))
-      (.releaseItem pool instance)
-      (is (= true @cleared?))
-      (is (= 0 (.currentSize pool))))))
-
 (deftest pool-remaining-capacity
   (testing "remaining capacity in pool correct per instances registered"
     (let [empty-pool (create-empty-pool)

--- a/test/unit/puppetlabs/jruby_utils/lockable_ref_pool_test.clj
+++ b/test/unit/puppetlabs/jruby_utils/lockable_ref_pool_test.clj
@@ -1,0 +1,638 @@
+(ns puppetlabs.jruby_utils.lockable-ref-pool-test
+  (:require [clojure.test :refer :all]
+            [puppetlabs.services.jruby-pool-manager.jruby-testutils :as jruby-testutils])
+  (:import (com.puppetlabs.jruby_utils.pool ReferencePool)
+           (java.util.concurrent TimeUnit ExecutionException TimeoutException)))
+
+(defn timed-deref
+  [ref]
+  (deref ref 10000 :timed-out))
+
+(defn create-empty-pool
+  ([] (create-empty-pool 10))
+  ([maxBorrows]
+   (ReferencePool. maxBorrows)))
+
+(defn create-populated-pool
+  ([] create-populated-pool 10)
+  ([size]
+   (let [pool (create-empty-pool size)]
+     (.register pool (str "foo"))
+     pool)))
+
+(defn borrow-n-instances
+  [pool n]
+  (doall (for [_ (range n)]
+           (.borrowItem pool))))
+
+(defn return-instances
+  [pool instances]
+  (doseq [instance instances]
+    (.releaseItem pool instance)))
+
+(deftest pool-register-above-maximum-throws-exception-test
+  (testing "attempt to register new instance with pool at max capacity fails"
+    (let [pool (create-empty-pool)]
+      (.register pool "foo ok")
+      (is (thrown? IllegalStateException
+                   (.register pool "foo bar"))))))
+
+(deftest pool-lock-is-blocking-until-borrows-returned-test
+  (let [pool (create-populated-pool 3)
+        instances (borrow-n-instances pool 3)
+        future-started? (promise)
+        lock-acquired? (promise)
+        unlock? (promise)]
+    (is (= 3 (count instances)))
+    (is (not (.isLocked pool)))
+    (let [lock-thread (future (deliver future-started? true)
+                              (.lock pool)
+                              (deliver lock-acquired? true)
+                              @unlock?
+                              (.unlock pool)
+                              true)]
+      @future-started?
+      (testing "pool.lock() blocks until all instances are returned to the pool"
+        (is (not (realized? lock-acquired?)))
+
+        (testing (str "other threads may successfully return instances while "
+                      "pool.lock() is being executed")
+          (.releaseItem pool (first instances))
+          (is (not (realized? lock-acquired?)))
+          (.releaseItem pool (second instances))
+          (is (not (realized? lock-acquired?)))
+          (.releaseItem pool (nth instances 2)))
+
+        (is (true? (timed-deref lock-acquired?))
+            "timed out waiting for the lock to be acquired")
+        (is (not (realized? lock-thread)))
+        (is (.isLocked pool))
+        (deliver unlock? true)
+        (is (true? (timed-deref lock-thread))
+            "timed out waiting for the lock thread to finish")
+        (is (not (.isLocked pool))))
+
+      (testing "borrows may be resumed after unlock()"
+        (let [instance (.borrowItem pool)]
+          (.releaseItem pool instance))
+        ;; make sure we got here
+        (is (true? true))))))
+
+(deftest pool-lock-blocks-borrows-test
+  (testing "no other threads may borrow once pool.lock() has been invoked (before or after it returns)"
+    (let [pool (create-populated-pool 2)
+          instances (borrow-n-instances pool 2)
+          lock-thread-started? (promise)
+          lock-acquired? (promise)
+          unlock? (promise)]
+      (is (= 2 (count instances)))
+      (is (not (.isLocked pool)))
+      (let [lock-thread (future (deliver lock-thread-started? true)
+                                (.lock pool)
+                                (deliver lock-acquired? true)
+                                @unlock?
+                                (.unlock pool)
+                                true)]
+        @lock-thread-started?
+        (is (not (realized? lock-acquired?)))
+        (let [borrow-after-lock-requested-thread-started? (promise)
+              borrow-after-lock-requested-instance-acquired? (promise)
+              borrow-after-lock-requested-thread
+              (future (deliver borrow-after-lock-requested-thread-started? true)
+                      (let [instance (.borrowItem pool)]
+                        (deliver borrow-after-lock-requested-instance-acquired? true)
+                        (.releaseItem pool instance))
+                      true)]
+          @borrow-after-lock-requested-thread-started?
+          (is (not (realized? borrow-after-lock-requested-instance-acquired?)))
+
+          (return-instances pool instances)
+          (is (true? (timed-deref lock-acquired?))
+              "timed out waiting for the lock acquired thread to start")
+          (is (.isLocked pool))
+          (is (not (realized? borrow-after-lock-requested-instance-acquired?)))
+          (is (not (realized? lock-thread)))
+
+          (let [borrow-after-lock-acquired-thread-started? (promise)
+                borrow-after-lock-acquired-instance-acquired? (promise)
+                borrow-after-lock-acquired-thread
+                (future (deliver borrow-after-lock-acquired-thread-started?
+                                 true)
+                        (let [instance (.borrowItem pool)]
+                          (deliver borrow-after-lock-acquired-instance-acquired? true)
+                          (.releaseItem pool instance))
+                        true)]
+            @borrow-after-lock-acquired-thread-started?
+            (is (not (realized? borrow-after-lock-acquired-instance-acquired?)))
+
+            (deliver unlock? true)
+
+            (is (true? (timed-deref lock-thread))
+                "timed out waiting for the lock thread to finish")
+            (is (true? (timed-deref
+                        borrow-after-lock-requested-instance-acquired?))
+                (str "timed out waiting for the borrow after lock requested "
+                     "to be completed"))
+            (is (true? (timed-deref
+                        borrow-after-lock-requested-thread))
+                (str "timed out waiting for the borrow after lock requested "
+                     "thread to finish"))
+            (is (true? (timed-deref
+                        borrow-after-lock-acquired-instance-acquired?))
+                "timed out waiting for the borrow after lock acquired")
+            (is (true? (timed-deref
+                        borrow-after-lock-acquired-thread))
+                (str "timed out waiting for the borrow after lock acquired "
+                     "thread to finish")))))
+            (is (not (.isLocked pool))))))
+
+(deftest pool-lock-supersedes-existing-borrows-test
+  (testing "if there are pending borrows when pool.lock() is called, they aren't fulfilled until after unlock()"
+    (let [pool (create-populated-pool 2)
+          instances (borrow-n-instances pool 2)
+          blocked-borrow-thread-started? (promise)
+          blocked-borrow-thread-borrowed? (promise)
+          blocked-borrow-thread (future (deliver blocked-borrow-thread-started? true)
+                                        (let [instance (.borrowItem pool)]
+                                          (deliver blocked-borrow-thread-borrowed? true)
+                                          (.releaseItem pool instance))
+                                        true)
+          lock-thread-started? (promise)
+          lock-acquired? (promise)
+          unlock? (promise)
+          lock-thread (future (deliver lock-thread-started? true)
+                              (.lock pool)
+                              (deliver lock-acquired? true)
+                              @unlock?
+                              (.unlock pool)
+                              true)]
+      @blocked-borrow-thread-started?
+      @lock-thread-started?
+      (is (not (realized? blocked-borrow-thread-borrowed?)))
+      (let [start (System/currentTimeMillis)]
+        (while (and (not (.isLocked pool))
+                    (< (- (System/currentTimeMillis) start) 10000))
+          (Thread/yield)))
+      (is (.isLocked pool))
+      (is (not (realized? lock-acquired?)))
+
+      (return-instances pool instances)
+      (is (not (realized? blocked-borrow-thread-borrowed?)))
+      (is (not (realized? lock-thread)))
+      (is (true? (timed-deref lock-acquired?))
+          "timed out waiting for the lock to be acquired")
+      (is (.isLocked pool))
+
+      (deliver unlock? true)
+      (is (true? (timed-deref lock-thread))
+          "timed out waiting for the lock thread to finish")
+      (is (true? (timed-deref blocked-borrow-thread-borrowed?))
+          "timed out waiting for the borrow to complete")
+      (is (true? (timed-deref blocked-borrow-thread))
+          "timed out waiting for the borrow thread to complete")
+      (is (not (.isLocked pool))))))
+
+(deftest pool-lock-reentrant-for-borrow-from-locking-thread
+  (testing "the thread that holds the pool lock may borrow instances while holding the lock"
+    (let [pool (create-populated-pool 2)]
+      (is (not (.isLocked pool)))
+      (.lock pool)
+      (is (.isLocked pool))
+      (let [instance (.borrowItem pool)]
+        (is (true? true))
+        (.releaseItem pool instance))
+      (is (true? true))
+      (.unlock pool)
+      (is (not (.isLocked pool))))))
+
+(deftest pool-lock-reentrant-with-many-borrows-test
+  (testing "the thread that holds the pool lock may borrow instances while holding the lock, even with other borrows queued"
+    (let [pool (create-populated-pool 2)]
+      (is (not (.isLocked pool)))
+      (.lock pool)
+      (is (.isLocked pool))
+      (let [borrow-thread-started-1? (promise)
+            borrow-thread-started-2? (promise)
+            borrow-thread-borrowed-1? (promise)
+            borrow-thread-borrowed-2? (promise)
+            borrow-thread-1 (future (deliver borrow-thread-started-1? true)
+                                    (let [instance (.borrowItem pool)]
+                                      (deliver borrow-thread-borrowed-1? true)
+                                      (.releaseItem pool instance))
+                                    true)
+            borrow-thread-2 (future (deliver borrow-thread-started-2? true)
+                                    (let [instance (.borrowItem pool)]
+                                      (deliver borrow-thread-borrowed-2? true)
+                                      (.releaseItem pool instance))
+                                    true)]
+        @borrow-thread-started-1?
+        @borrow-thread-started-2?
+        (is (not (realized? borrow-thread-borrowed-1?)))
+        (is (not (realized? borrow-thread-borrowed-2?)))
+
+        (let [instance (.borrowItem pool)]
+          (is (true? true))
+          (.releaseItem pool instance))
+
+        (is (true? true))
+        (.unlock pool)
+        (is (true? (timed-deref borrow-thread-1))
+            "timed out waiting for first borrow thread to finish")
+        (is (true? (timed-deref borrow-thread-2))
+            "timed out waiting for second borrow thread to finish"))
+        (is (not (.isLocked pool))))))
+
+(deftest pool-lock-reentrant-for-many-locks-test
+  (testing "multiple threads cannot lock the pool while it is already locked"
+    (let [pool (create-populated-pool 1)]
+      (is (not (.isLocked pool)))
+      (.lock pool)
+      (is (.isLocked pool))
+      (let [lock-thread-started-1? (promise)
+            lock-thread-started-2? (promise)
+            lock-thread-locked-1? (promise)
+            lock-thread-locked-2? (promise)
+            lock-thread-1 (future (deliver lock-thread-started-1? true)
+                                  (.lock pool)
+                                  (deliver lock-thread-locked-1? true)
+                                  (.unlock pool)
+                                  true)
+            lock-thread-2 (future (deliver lock-thread-started-2? true)
+                                  (.lock pool)
+                                  (deliver lock-thread-locked-2? true)
+                                  (.unlock pool)
+                                  true)]
+        @lock-thread-started-1?
+        @lock-thread-started-2?
+        (is (not (realized? lock-thread-locked-1?)))
+        (is (not (realized? lock-thread-locked-2?)))
+        (.unlock pool)
+        (is (true? (timed-deref lock-thread-1))
+            "timed out waiting for first lock thread to finish")
+        (is (true? (timed-deref lock-thread-2))
+            "timed out waiting for second lock thread to finish"))
+        (is (not (.isLocked pool))))))
+
+(deftest pool-lock-not-held-after-thread-interrupt
+  (let [pool (create-populated-pool 1)
+        item (.borrowItem pool)
+        lock-thread-obj (promise)
+        lock-thread-locked? (promise)
+        lock-thread (future (deliver lock-thread-obj (Thread/currentThread))
+                            (.lock pool)
+                            (deliver lock-thread-locked? true))]
+    (testing (str "write locker's thread can be interrupted while waiting for "
+                  "instances to be returned")
+      (.interrupt @lock-thread-obj)
+      (is (thrown? ExecutionException (timed-deref lock-thread)))
+      (is (not (realized? lock-thread-locked?))))
+      (is (not (.isLocked pool)))
+
+    (.releaseItem pool item)
+    (testing "new write lock can be taken after prior write lock interrupted"
+      (.lock pool)
+      (is (.isLocked pool)))))
+
+(deftest pool-unlock-from-thread-not-holding-lock-fails
+  (testing "call to unlock pool when no lock held throws exception"
+    (let [pool (create-populated-pool 1)]
+      (is (thrown? IllegalStateException (.unlock pool)))))
+  (testing "call to unlock pool from thread not holding lock throws exception"
+    (let [pool (create-populated-pool 1)
+          lock-started? (promise)
+          unlock? (promise)
+          lock-thread (future (.lock pool)
+                              (deliver lock-started? true)
+                              @unlock?
+                              (.unlock pool)
+                              true)]
+      @lock-started?
+      (is (.isLocked pool))
+      (is (thrown? IllegalStateException (.unlock pool)))
+      (deliver unlock? true)
+      (is (true? (timed-deref lock-thread))
+          "timed out waiting for lock thread to finish")
+      (is (not (.isLocked pool))))))
+
+(deftest pool-lock-with-timeout-test
+  (testing "lock is granted if timeout is not exceeded"
+    (let [pool (create-populated-pool 1)]
+      (.lockWithTimeout pool 1 TimeUnit/NANOSECONDS)
+      (is (.isLocked pool))))
+  (testing "lock throws TimeoutException if timeout is exceeded"
+    (let [pool (create-populated-pool 1)
+          borrowed-instance (.borrowItem pool)]
+      (is (thrown-with-msg?
+           TimeoutException
+           #"Timeout limit reached before lock could be granted"
+           (.lockWithTimeout pool 1 TimeUnit/NANOSECONDS)
+           (is (not (.isLocked pool))))))))
+
+(deftest pool-release-item-test
+  (testing "releaseItem returns item to pool and allows pool to still be lockable"
+    (let [pool (create-populated-pool 2)
+          instance (.borrowItem pool)]
+      (is (= 1 (.size pool)))
+      (.releaseItem pool instance)
+      (is (= 2 (.size pool)))
+      (is (not (.isLocked pool)))
+      (.lock pool)
+      (is (.isLocked pool))
+      (is (nil? (timed-deref
+                 (future (.borrowItemWithTimeout pool
+                                                 1
+                                                 TimeUnit/MICROSECONDS))))
+          "timed out waiting for borrow with timeout in lock to finish")
+      (.unlock pool)
+      (is (not (nil? (timed-deref
+                      (future (.borrowItemWithTimeout pool
+                                                      1
+                                                      TimeUnit/MICROSECONDS)))))
+          "timed out waiting for borrow with timeout after unlock to finish")
+      (is (not (.isLocked pool))))))
+
+(deftest pool-borrow-blocks-borrow-when-pool-empty
+  (testing "borrow from pool blocks while the pool is empty"
+    (let [pool (create-populated-pool 1)
+          item (.borrowItem pool)
+          borrow-thread-started? (promise)
+          borrow-thread-borrowed? (promise)
+          borrow-thread (future (deliver borrow-thread-started? true)
+                                (let [instance (.borrowItem pool)]
+                                  (deliver borrow-thread-borrowed? true)
+                                  (.releaseItem pool instance))
+                                true)]
+      @borrow-thread-started?
+      (is (not (realized? borrow-thread-borrowed?)))
+      (.releaseItem pool item)
+      (is (true? (timed-deref borrow-thread))
+          "timed out waiting for borrow thread to finish"))))
+
+(deftest pool-timed-borrows-test
+  (testing "pool borrows with timeout"
+    (let [pool (create-populated-pool 1)
+          item (.borrowItem pool)]
+      (testing "borrow times out and returns nil when pool is empty"
+        (is (nil? (timed-deref
+                   (future (.borrowItemWithTimeout pool
+                                                   1
+                                                   TimeUnit/MICROSECONDS))))))
+      (.releaseItem pool item)
+      (testing "borrow succeeds when pool is non-empty"
+        (is (identical? item (timed-deref
+                              (future (.borrowItemWithTimeout
+                                       pool
+                                       1
+                                       TimeUnit/MICROSECONDS)))))))))
+
+(deftest pool-can-do-blocking-borrow-after-borrow-timed-out
+  (testing "can do blocking borrow from pool after previous borrow timed out"
+    (let [pool (create-populated-pool 1)
+          item (.borrowItem pool)]
+      (is (nil? (.borrowItemWithTimeout pool 1 TimeUnit/MICROSECONDS)))
+      (let [borrow-thread-started? (promise)
+            borrow-thread-borrowed? (promise)
+            borrow-thread (future (deliver borrow-thread-started? true)
+                                  (let [instance (.borrowItem pool)]
+                                    (deliver borrow-thread-borrowed? true)
+                                    (.releaseItem pool instance))
+                                  true)]
+        @borrow-thread-started?
+        (is (not (realized? borrow-thread-borrowed?)))
+        (.releaseItem pool item)
+        (is (true? (timed-deref borrow-thread))
+            "timed out waiting for borrow thread to finish")))))
+
+(deftest pool-can-do-blocking-borrow-after-borrow-timed-out-during-lock
+  (testing (str "can do a blocking borrow from pool after previous borrow "
+                "timed out while a write lock was held")
+    (let [pool (create-populated-pool 1)]
+      (.lock pool)
+      (is (.isLocked pool))
+      (is (nil? (timed-deref
+                 (future (.borrowItemWithTimeout pool
+                                                 1
+                                                 TimeUnit/MICROSECONDS))))
+          "timed out waiting for borrow with timeout to finish")
+
+      (let [borrow-thread-started? (promise)
+            borrow-thread-borrowed? (promise)
+            borrow-thread (future (deliver borrow-thread-started? true)
+                                  (let [instance (.borrowItem pool)]
+                                    (deliver borrow-thread-borrowed? true)
+                                    (.releaseItem pool instance))
+                                  true)]
+        @borrow-thread-started?
+        (is (not (realized? borrow-thread-borrowed?)))
+        (.unlock pool)
+        (is (true? (timed-deref borrow-thread))
+            "timed out waiting for borrow thread to finish")
+        (is (not (.isLocked pool)))))))
+
+(deftest pool-can-borrow-after-borrow-interrupted-during-lock
+  (testing (str "can do a borrow after another borrow was interrupted "
+                "while a write lock was held")
+    (let [pool (create-populated-pool 1)
+          borrow-1 (.borrowItem pool)
+          borrow-thread-started-2 (promise)
+          borrow-thread-started-3? (promise)
+          lock-thread-locked? (promise)
+          borrow-thread-2 (future
+                           (deliver borrow-thread-started-2
+                                    (Thread/currentThread))
+                           (timed-deref lock-thread-locked?)
+                           (.borrowItem pool))
+          borrow-thread-3 (future
+                           (deliver borrow-thread-started-3? true)
+                           (timed-deref lock-thread-locked?)
+                           (.borrowItem pool))
+          borrow-thread-obj-2 @borrow-thread-started-2
+          _ @borrow-thread-started-3?
+          lock-thread-started? (promise)
+          unlock? (promise)
+          lock-thread (future
+                       (deliver lock-thread-started? true)
+                       (.lock pool)
+                       (deliver lock-thread-locked? true)
+                       @unlock?
+                       (.unlock pool)
+                       true)]
+      @lock-thread-started?
+      (.releaseItem pool borrow-1)
+      (is (true? (timed-deref lock-thread-locked?))
+          "timed out waiting for the lock to be acquired")
+      (is (true? (.isLocked pool)))
+      ;; Interrupt the second borrow thread so that it will stop waiting for the
+      ;; pool to be not empty and not locked.
+      (.interrupt borrow-thread-obj-2)
+      (is (thrown? ExecutionException (timed-deref borrow-thread-2))
+          "second borrow could not be interrupted")
+      (is (not (realized? borrow-thread-3)))
+      (deliver unlock? true)
+      (is (true? (timed-deref lock-thread))
+          "timed out waiting for the lock thread to finish")
+      (is (not (.isLocked pool)))
+      ;; If the third borrow doesn't block indefinitely, we've confirmed that
+      ;; the interruption of the second borrow while the write lock was
+      ;; held did not adversely affect the ability of the third borrow call
+      ;; to return.
+      (is (identical? borrow-1 (timed-deref borrow-thread-3))
+          (str "did not get back the same instance from the third borrow "
+               "attempt as was returned from the first borrow attempt")))))
+
+(deftest pool-can-borrow-after-borrow-timed-out-during-lock
+  (testing (str "can do a timed borrow from pool after previous borrow "
+                "timed out while a write lock was held")
+    (let [pool (create-populated-pool 1)
+          borrow-1 (.borrowItem pool)
+          borrow-thread-started-2? (promise)
+          borrow-thread-started-3? (promise)
+          lock-thread-locked? (promise)
+          borrow-thread-2 (future
+                           (deliver borrow-thread-started-2? true)
+                           (timed-deref lock-thread-locked?)
+                           (.borrowItemWithTimeout
+                            pool
+                            50
+                            TimeUnit/MILLISECONDS))
+          borrow-thread-3 (future
+                           (deliver borrow-thread-started-3? true)
+                           (timed-deref lock-thread-locked?)
+                           (.borrowItemWithTimeout pool
+                                                   1
+                                                   TimeUnit/SECONDS))
+          _ @borrow-thread-started-2?
+          _ @borrow-thread-started-3?
+          unlock? (promise)
+          lock-thread-started? (promise)
+          lock-thread (future
+                       (deliver lock-thread-started? true)
+                       (.lock pool)
+                       (deliver lock-thread-locked? true)
+                       @unlock?
+                       (.unlock pool)
+                       true)]
+      @lock-thread-started?
+      (.releaseItem pool borrow-1)
+      (is (true? (timed-deref lock-thread-locked?))
+          "timed out waiting for the lock to be acquired")
+      (is (.isLocked pool))
+      (is (nil? (timed-deref borrow-thread-2))
+          "second borrow attempt did not time out")
+      (deliver unlock? true)
+      (is (true? (timed-deref lock-thread))
+          "timed out waiting for the lock thread to finish")
+      (is (not (.isLocked pool)))
+      (is (identical? borrow-1 (timed-deref borrow-thread-3))
+          (str "did not get back the same instance from the third borrow"
+               "attempt as was returned from the first borrow attempt")))))
+
+(deftest pool-insert-pill-test
+  (testing "inserted pill is next item borrowed"
+    (let [pool (create-populated-pool 1)
+          pill (str "i'm a pill")]
+      (.insertPill pool pill)
+      (is (identical? (.borrowItem pool) pill))
+      (testing "subsequent borrows return the same pill"
+        (is (identical? (.borrowItem pool) pill)))))
+  (testing "when borrow is blocked, inserting a pill unblocks it"
+    (let [pool (create-populated-pool 1)
+          pill (str "I'm just a pill, yes I'm only a pill")
+          _ (.borrowItem pool)
+          blocked-borrow (future (.borrowItem pool))]
+      (is (= 0 (.size pool)))
+
+      ; Give future a chance to run and block
+      (Thread/sleep 500)
+      ; Pool is empty and the borrow future is blocked
+      (is (not (realized? blocked-borrow)))
+      ; inserting the pill should unblock the promise
+      (.insertPill pool pill)
+      ; borrow finishes and gives us back the pill
+      (let [future-result (timed-deref blocked-borrow)]
+        (is (identical? future-result pill)))))
+
+  (testing "second insert doesn't change the pill"
+    (let [pool (create-populated-pool 1)
+          first-pill (str "pill clinton")
+          second-pill (str "pillary clinton")]
+      (.insertPill pool first-pill)
+      (is (identical? first-pill (.borrowItem pool)))
+
+      (.insertPill pool second-pill)
+      ; Should still be equal to the first pill
+      (is (identical? first-pill (.borrowItem pool)))
+      (is (not (identical? second-pill (.borrowItem pool)))))))
+
+(deftest release-item-exceptions-test
+  (testing "releasing a different pill than the one that was inserted errors"
+    (let [pool (create-populated-pool 1)
+          first-pill (str "a city upon a pill")
+          second-pill (str "capitol pill")]
+      (.insertPill pool first-pill)
+      ; Only to show that it does not error
+      (is (nil? (.releaseItem pool first-pill)))
+      (is (thrown-with-msg?
+           IllegalArgumentException
+           #"The item being released is not registered with the pool"
+           (.releaseItem pool second-pill)))))
+
+  (testing "releasing a jruby not registered with the pool errors"
+    (let [pool (create-populated-pool 1)
+          not-in-pool-instance "I was never registered"]
+      (is (thrown-with-msg?
+           IllegalArgumentException
+           #"The item being released is not registered with the pool"
+           (.releaseItem pool not-in-pool-instance))))))
+
+(deftest lock-interrupted-by-pill-insertion-test
+  (testing "a call to .lock will throw if there is a pill"
+    (let [pool (create-populated-pool 1)
+          pill "pilliam shakespeare"]
+      (.insertPill pool pill)
+      (is (thrown-with-msg?
+           InterruptedException
+           #"Lock can't be granted because a pill has been inserted"
+           (.lock pool)))))
+
+  (testing "a blocked .lock call throws an InterruptedException once a pill is inserted"
+    (let [pool (create-populated-pool 1)
+          pill "pillful ignorance"]
+      ; Make it so the pool is not full
+      (.borrowItem pool)
+
+      ; Exceptions thrown from the future will be returned as InterruptedException,
+      ; so we can't use thrown-with-msg?. We'll catch it, return it instead of
+      ; throwing it, and inspect it manually below
+      (let [blocked-lock-future (future (try (.lock pool)
+                                             (catch InterruptedException e
+                                               e)))]
+        ; The future's thread will take the lock, and then block waiting for
+        ; either the pool to fill up, or a pill to be inserted
+        (jruby-testutils/wait-for-pool-to-be-locked pool)
+        (.insertPill pool pill)
+        (let [exception @blocked-lock-future]
+          (is (= InterruptedException (type exception)))
+          (is (= "Lock can't be granted because a pill has been inserted"
+                 (.getMessage exception))))))))
+
+(deftest pool-clear-test
+  (testing (str "clear blocks waiting for all references to be returned")
+    (let [pool (create-populated-pool 2)
+          instance (.borrowItem pool)
+          cleared? (promise)
+          _ (future
+              (.clear pool)
+              (deliver cleared? true))]
+      (is (= 1 (.size pool)))
+      (is (= false (realized? cleared?)))
+      (.releaseItem pool instance)
+      (is (= true @cleared?))
+      (is (= 0 (.size pool))))))
+
+(deftest pool-remaining-capacity
+  (testing "remaining capacity in pool correct per instances registered"
+    (let [empty-pool (create-empty-pool)
+          pool (create-populated-pool 5)]
+      (is (= 1 (.remainingCapacity empty-pool)))
+      (is (= 0 (.remainingCapacity pool))))))

--- a/test/unit/puppetlabs/services/jruby_pool_manager/jruby_agents_test.clj
+++ b/test/unit/puppetlabs/services/jruby_pool_manager/jruby_agents_test.clj
@@ -45,6 +45,6 @@
        (try
          (is (= 4 (count jruby-list)))
          (is (every? #(instance? JRubyInstance %) jruby-list))
-         (is (= 0 (.size pool)))
+         (is (= 0 (.currentSize pool)))
          (finally
            (jruby-testutils/fill-drained-pool jruby-list)))))))

--- a/test/unit/puppetlabs/services/jruby_pool_manager/jruby_agents_test.clj
+++ b/test/unit/puppetlabs/services/jruby_pool_manager/jruby_agents_test.clj
@@ -47,4 +47,4 @@
          (is (every? #(instance? JRubyInstance %) jruby-list))
          (is (= 0 (.currentSize pool)))
          (finally
-           (jruby-testutils/fill-drained-pool jruby-list)))))))
+           (jruby-testutils/fill-drained-pool pool-context jruby-list)))))))

--- a/test/unit/puppetlabs/services/jruby_pool_manager/jruby_pool_test.clj
+++ b/test/unit/puppetlabs/services/jruby_pool_manager/jruby_pool_test.clj
@@ -8,7 +8,8 @@
             [puppetlabs.services.jruby-pool-manager.impl.jruby-internal :as jruby-internal]
             [puppetlabs.trapperkeeper.testutils.logging :as logutils]
             [puppetlabs.services.jruby-pool-manager.impl.jruby-pool-manager-core :as jruby-pool-manager-core]
-            [puppetlabs.services.jruby-pool-manager.jruby-schemas :as jruby-schemas])
+            [puppetlabs.services.jruby-pool-manager.jruby-schemas :as jruby-schemas]
+            [puppetlabs.services.protocols.jruby-pool :as pool-protocol])
   (:import (clojure.lang ExceptionInfo)
            (puppetlabs.services.jruby_pool_manager.jruby_schemas ShutdownPoisonPill)))
 
@@ -296,14 +297,13 @@
          (is (= 1 (count (jruby-core/registered-instances pool-context))))))
      (testing "Can lock pool after a flush via max borrows"
        (let [timeout 1
-             new-pool-context (assoc-in pool-context [:config :borrow-timeout] timeout)
-             pool (jruby-internal/get-pool new-pool-context)]
-         (.lock pool)
+             new-pool-context (assoc-in pool-context [:config :borrow-timeout] timeout)]
+         (pool-protocol/lock new-pool-context)
          (is (nil? @(future (jruby-core/borrow-from-pool-with-timeout
                              new-pool-context
                              :test
                              []))))
-         (.unlock pool)
+         (pool-protocol/unlock new-pool-context)
          (let [instance @(future (jruby-core/borrow-from-pool-with-timeout
                                   new-pool-context
                                   :test

--- a/test/unit/puppetlabs/services/jruby_pool_manager/jruby_ref_pool_test.clj
+++ b/test/unit/puppetlabs/services/jruby_pool_manager/jruby_ref_pool_test.clj
@@ -1,0 +1,2 @@
+(ns puppetlabs.services.jruby-pool-manager.jruby-ref-pool-test
+  (:require [clojure.test :refer :all]))

--- a/test/unit/puppetlabs/services/jruby_pool_manager/jruby_ref_pool_test.clj
+++ b/test/unit/puppetlabs/services/jruby_pool_manager/jruby_ref_pool_test.clj
@@ -1,2 +1,107 @@
 (ns puppetlabs.services.jruby-pool-manager.jruby-ref-pool-test
-  (:require [clojure.test :refer :all]))
+  (:require [clojure.test :refer :all]
+            [puppetlabs.services.jruby-pool-manager.jruby-testutils :as jruby-testutils]
+            [puppetlabs.services.jruby-pool-manager.jruby-core :as jruby-core]
+            [puppetlabs.services.protocols.jruby-pool :as pool-protocol]))
+
+(defn jruby-test-config
+  ([max-borrows]
+   (jruby-test-config max-borrows 1))
+  ([max-borrows max-instances]
+   (jruby-testutils/jruby-config {:max-active-instances max-instances
+                                  :multithreaded true
+                                  :max-borrows-per-instance max-borrows})))
+
+(deftest more-borrows-than-mrpi
+  (testing "flushing due to max borrows succeeds when we've over-borrowed")
+  (jruby-testutils/with-pool-context
+    pool-context
+    jruby-testutils/default-services
+    ;; We can check out the instance more times than `max-borrows` and return
+    ;; them each in sequence, and nothing blocks or fails
+    (jruby-testutils/jruby-config {:max-active-instances 4
+                                   :multithreaded true
+                                   :max-borrows-per-instance 3})
+    (let [instance (jruby-core/borrow-from-pool pool-context :test [])]
+      (is (= 1 (:id instance)))
+      (jruby-core/return-to-pool pool-context instance :test []))
+    (jruby-testutils/drain-and-refill pool-context)
+    (let [instance (jruby-core/borrow-from-pool pool-context :test [])]
+      (is (= 2 (:id instance)))
+      (jruby-core/return-to-pool pool-context instance :test []))))
+
+
+(deftest flush-jruby-after-max-borrows
+  (testing "JRubyInstance is not flushed if it has not exceeded max borrows"
+    (jruby-testutils/with-pool-context
+      pool-context
+      jruby-testutils/default-services
+      (jruby-test-config 2)
+      (let [instance (jruby-core/borrow-from-pool pool-context :test [])
+            id (:id instance)]
+        (jruby-core/return-to-pool pool-context instance :test [])
+        (let [instance (jruby-core/borrow-from-pool pool-context :test [])]
+          (is (= id (:id instance)))
+          (jruby-core/return-to-pool pool-context instance :test [])))))
+  (testing "JRubyInstance is flushed after exceeding max borrows"
+    (jruby-testutils/with-pool-context
+      pool-context
+      jruby-testutils/default-services
+      (jruby-test-config 2)
+      (jruby-testutils/wait-for-jrubies-from-pool-context pool-context)
+      (is (= 1 (count (jruby-core/registered-instances pool-context))))
+      (let [instance (jruby-core/borrow-from-pool pool-context :test [])
+            id (:id instance)]
+        (jruby-core/return-to-pool pool-context instance :test [])
+        (jruby-core/borrow-from-pool pool-context :test [])
+        (jruby-core/return-to-pool pool-context instance :test [])
+        (let [instance (jruby-core/borrow-from-pool pool-context :test [])]
+          (is (not= id (:id instance)))
+          (jruby-core/return-to-pool pool-context instance :test [])))
+      (testing "Can lock pool after a flush via max borrows"
+        (let [timeout 1
+              new-pool-context (assoc-in pool-context [:config :borrow-timeout] timeout)]
+          (pool-protocol/lock new-pool-context)
+          (is (nil? @(future (jruby-core/borrow-from-pool-with-timeout
+                                new-pool-context
+                                :test
+                                []))))
+          (pool-protocol/unlock new-pool-context)
+          (let [instance @(future (jruby-core/borrow-from-pool-with-timeout
+                                     new-pool-context
+                                     :test
+                                     []))]
+            (is (not (nil? instance)))
+            (jruby-core/return-to-pool pool-context instance :test []))))))
+  (testing "JRubyInstance is not flushed if max borrows setting is set to 0"
+    (jruby-testutils/with-pool-context
+      pool-context
+      jruby-testutils/default-services
+      (jruby-test-config 0)
+      (let [instance (jruby-core/borrow-from-pool pool-context :test [])
+            id (:id instance)]
+        (jruby-core/return-to-pool pool-context instance :test [])
+        (let [instance (jruby-core/borrow-from-pool pool-context :test [])]
+          (is (= id (:id instance)))
+          (jruby-core/return-to-pool pool-context instance :test [])))))
+  (testing "Cannot flush the JRubyInstance while it is borrowed"
+    (jruby-testutils/with-pool-context
+      pool-context
+      jruby-testutils/default-services
+      (jruby-test-config 2 3)
+      (let [reference1 (jruby-core/borrow-from-pool pool-context :test [])
+            reference2 (jruby-core/borrow-from-pool pool-context :test [])
+            id (:id reference2)]
+        (jruby-core/return-to-pool pool-context reference2 :test [])
+        ;; borrow a third time and confirm we get the same instance
+        (let [reference3 (jruby-core/borrow-from-pool pool-context :test [])
+              flushed (promise)]
+          (is (= id (:id reference3)))
+          (jruby-core/return-to-pool pool-context reference3 :test [])
+
+          (jruby-core/return-to-pool pool-context reference1 :test [])
+          (is (realized? flushed)))
+        ;; Should be a new jruby instance
+        (let [new-borrow (jruby-core/borrow-from-pool pool-context :test [])]
+          (is (not= id (:id new-borrow)))
+          (jruby-core/return-to-pool pool-context new-borrow :test []))))))

--- a/test/unit/puppetlabs/services/jruby_pool_manager/jruby_ref_pool_test.clj
+++ b/test/unit/puppetlabs/services/jruby_pool_manager/jruby_ref_pool_test.clj
@@ -19,8 +19,7 @@
       (jruby-testutils/with-pool-context
         pool-context
         jruby-testutils/default-services
-        (jruby-testutils/jruby-config {:max-active-instances pool-size
-                                       :multithreaded true})
+        (jruby-test-config 0 pool-size)
         ;; borrow both instances from the pool
         (let [drained-instances (jruby-testutils/drain-pool pool-context pool-size)]
           (try
@@ -60,9 +59,7 @@
     (jruby-testutils/with-pool-context
       pool-context
       jruby-testutils/default-services
-      (jruby-testutils/jruby-config {:max-active-instances 1
-                                     :multithreaded true
-                                     :max-borrows-per-instance 2})
+      (jruby-test-config 2 1)
       (let [instance (jruby-core/borrow-from-pool pool-context :test [])
             id (:id instance)]
         (jruby-core/return-to-pool pool-context instance :test [])
@@ -91,9 +88,7 @@
       jruby-testutils/default-services
       ;; We can check out the instance more times than `max-borrows` and return
       ;; them each in sequence, and nothing blocks or fails
-      (jruby-testutils/jruby-config {:max-active-instances 3
-                                     :multithreaded true
-                                     :max-borrows-per-instance 2})
+      (jruby-test-config 2 3)
       (let [instance1 (jruby-core/borrow-from-pool pool-context :test [])
             instance2 (jruby-core/borrow-from-pool pool-context :test [])
             instance3 (jruby-core/borrow-from-pool pool-context :test [])

--- a/test/unit/puppetlabs/services/jruby_pool_manager/jruby_ref_pool_test.clj
+++ b/test/unit/puppetlabs/services/jruby_pool_manager/jruby_ref_pool_test.clj
@@ -12,40 +12,47 @@
                                   :multithreaded true
                                   :max-borrows-per-instance max-borrows})))
 
+(deftest borrow-while-no-instances-available-test
+  (testing "when all instances are in use, borrow blocks until an instance becomes available"
+    (let [pool-size 2]
+      (jruby-testutils/with-pool-context
+        pool-context
+        jruby-testutils/default-services
+        (jruby-testutils/jruby-config {:max-active-instances pool-size
+                                       :multithreaded true})
+        ;; borrow both instances from the pool
+        (let [drained-instances (jruby-testutils/drain-pool pool-context pool-size)]
+          (try
+            (is (= 2 (count drained-instances)))
+
+            ;; attempt a borrow, which will block because no instances are free
+            (let [borrow-instance (future (jruby-core/borrow-from-pool-with-timeout
+                                             pool-context
+                                             :borrow-with-no-free-instances-test
+                                             []))]
+              (is (not (realized? borrow-instance)))
+
+              ;; return an instance to the pool
+              (jruby-core/return-to-pool pool-context
+                                          (first drained-instances)
+                                          :borrow-with-no-free-instances-test
+                                          [])
+
+              ;; now the borrow can complete
+              (is (some? @borrow-instance)))
+            (finally
+              (jruby-testutils/fill-drained-pool pool-context drained-instances))))))))
+
+
 (defn add-watch-for-flush-complete
   [pool-context]
   (let [flush-complete (promise)]
     (add-watch (get-in pool-context [:internal :modify-instance-agent]) :flush-callback
-               (fn [k a old-state new-state]
+               (fn [k a _ _]
                  (when (= k :flush-callback)
                    (remove-watch a :flush-callback)
                    (deliver flush-complete true))))
     flush-complete))
-
-(deftest more-borrows-than-mrpi
-  (testing "flushing due to max borrows succeeds when we've over-borrowed")
-  (jruby-testutils/with-pool-context
-    pool-context
-    jruby-testutils/default-services
-    ;; We can check out the instance more times than `max-borrows` and return
-    ;; them each in sequence, and nothing blocks or fails
-    (jruby-testutils/jruby-config {:max-active-instances 3
-                                   :multithreaded true
-                                   :max-borrows-per-instance 2})
-    (let [instance1 (jruby-core/borrow-from-pool pool-context :test [])
-          instance2 (jruby-core/borrow-from-pool pool-context :test [])
-          instance3 (jruby-core/borrow-from-pool pool-context :test [])
-          flush-complete (add-watch-for-flush-complete pool-context)]
-      (jruby-core/return-to-pool pool-context instance1 :test [])
-      (is (not (realized? flush-complete)))
-      (jruby-core/return-to-pool pool-context instance2 :test [])
-      (is (not (realized? flush-complete)))
-      (jruby-core/return-to-pool pool-context instance3 :test [])
-      (is @flush-complete))
-    (let [instance (jruby-core/borrow-from-pool pool-context :test [])]
-      (is (= 2 (:id instance)))
-      (jruby-core/return-to-pool pool-context instance :test []))))
-
 
 (deftest flush-jruby-after-max-borrows
   (testing "JRubyInstance is not flushed if it has not exceeded max borrows"
@@ -56,24 +63,12 @@
       (let [instance (jruby-core/borrow-from-pool pool-context :test [])
             id (:id instance)]
         (jruby-core/return-to-pool pool-context instance :test [])
-        (let [instance (jruby-core/borrow-from-pool pool-context :test [])]
+        (let [instance (jruby-core/borrow-from-pool pool-context :test [])
+              flush-complete (add-watch-for-flush-complete pool-context)]
           (is (= id (:id instance)))
-          (jruby-core/return-to-pool pool-context instance :test [])))))
-  (testing "JRubyInstance is flushed after exceeding max borrows"
-    (jruby-testutils/with-pool-context
-      pool-context
-      jruby-testutils/default-services
-      (jruby-test-config 2)
-      (jruby-testutils/wait-for-jrubies-from-pool-context pool-context)
-      (is (= 1 (count (jruby-core/registered-instances pool-context))))
-      (let [instance (jruby-core/borrow-from-pool pool-context :test [])
-            id (:id instance)]
-        (jruby-core/return-to-pool pool-context instance :test [])
-        (jruby-core/borrow-from-pool pool-context :test [])
-        (jruby-core/return-to-pool pool-context instance :test [])
-        (let [instance (jruby-core/borrow-from-pool pool-context :test [])]
-          (is (not= id (:id instance)))
-          (jruby-core/return-to-pool pool-context instance :test [])))
+          ;; This return will trigger the flush
+          (jruby-core/return-to-pool pool-context instance :test [])
+          (is @flush-complete)))
       (testing "Can lock pool after a flush via max borrows"
         (let [timeout 1
               new-pool-context (assoc-in pool-context [:config :borrow-timeout] timeout)]
@@ -89,6 +84,30 @@
                                      []))]
             (is (not (nil? instance)))
             (jruby-core/return-to-pool pool-context instance :test []))))))
+  (testing "flushing due to max borrows succeeds when we've over-borrowed"
+    (jruby-testutils/with-pool-context
+      pool-context
+      jruby-testutils/default-services
+      ;; We can check out the instance more times than `max-borrows` and return
+      ;; them each in sequence, and nothing blocks or fails
+      (jruby-testutils/jruby-config {:max-active-instances 3
+                                     :multithreaded true
+                                     :max-borrows-per-instance 2})
+      (let [instance1 (jruby-core/borrow-from-pool pool-context :test [])
+            instance2 (jruby-core/borrow-from-pool pool-context :test [])
+            instance3 (jruby-core/borrow-from-pool pool-context :test [])
+            flush-complete (add-watch-for-flush-complete pool-context)]
+        (jruby-core/return-to-pool pool-context instance1 :test [])
+        (is (not (realized? flush-complete)))
+        ;; This return triggers the flush
+        (jruby-core/return-to-pool pool-context instance2 :test [])
+        ;; But it doesn't finish till the other borrow is returned
+        (is (not (realized? flush-complete)))
+        (jruby-core/return-to-pool pool-context instance3 :test [])
+        (is @flush-complete))
+      (let [instance (jruby-core/borrow-from-pool pool-context :test [])]
+        (is (= 2 (:id instance)))
+        (jruby-core/return-to-pool pool-context instance :test []))))
   (testing "JRubyInstance is not flushed if max borrows setting is set to 0"
     (jruby-testutils/with-pool-context
       pool-context
@@ -99,25 +118,4 @@
         (jruby-core/return-to-pool pool-context instance :test [])
         (let [instance (jruby-core/borrow-from-pool pool-context :test [])]
           (is (= id (:id instance)))
-          (jruby-core/return-to-pool pool-context instance :test [])))))
-  (testing "Cannot flush the JRubyInstance while it is borrowed"
-    (jruby-testutils/with-pool-context
-      pool-context
-      jruby-testutils/default-services
-      (jruby-test-config 2 3)
-      (let [reference1 (jruby-core/borrow-from-pool pool-context :test [])
-            reference2 (jruby-core/borrow-from-pool pool-context :test [])
-            id (:id reference2)]
-        (jruby-core/return-to-pool pool-context reference2 :test [])
-        ;; borrow a third time and confirm we get the same instance
-        (let [reference3 (jruby-core/borrow-from-pool pool-context :test [])
-              flushed (promise)]
-          (is (= id (:id reference3)))
-          (jruby-core/return-to-pool pool-context reference3 :test [])
-
-          (jruby-core/return-to-pool pool-context reference1 :test [])
-          (is (realized? flushed)))
-        ;; Should be a new jruby instance
-        (let [new-borrow (jruby-core/borrow-from-pool pool-context :test [])]
-          (is (not= id (:id new-borrow)))
-          (jruby-core/return-to-pool pool-context new-borrow :test []))))))
+          (jruby-core/return-to-pool pool-context instance :test []))))))

--- a/test/unit/puppetlabs/services/jruby_pool_manager/jruby_service_test.clj
+++ b/test/unit/puppetlabs/services/jruby_pool_manager/jruby_service_test.clj
@@ -84,7 +84,7 @@
           (doseq [instance all-the-instances]
             (is (not (nil? instance))
                 "One of the JRubyInstances retrieved from the pool is nil")
-            (jruby-core/return-to-pool instance :test-pool-size []))
+            (jruby-core/return-to-pool pool-context instance :test-pool-size []))
           (is (= pool-size (jruby-core/free-instance-count pool))))))))
 
 (deftest test-with-jruby-instance
@@ -114,7 +114,7 @@
        ;; pool, so right now it should be at 2 since we've called
        ;; `with-jruby-instance` twice.
        (is (= 2 (:borrow-count (jruby-core/get-instance-state jruby))))
-       (jruby-core/return-to-pool jruby :test-with-jruby-instance [])))))
+       (jruby-core/return-to-pool pool-context jruby :test-with-jruby-instance [])))))
 
 (deftest test-jruby-events
   (testing "jruby service sends event notifications"
@@ -190,7 +190,7 @@
            (is (= (:borrow-timeout (:config pool-context)) timeout)))
          ; Test cleanup. This instance needs to be returned so that the stop can complete.
          (doseq [inst jrubies]
-           (jruby-core/return-to-pool inst :test []))))))
+           (jruby-core/return-to-pool pool-context inst :test []))))))
 
   (testing (str ":borrow-timeout defaults to " jruby-core/default-borrow-timeout " milliseconds")
     (let [initial-config {:ruby-load-path ["foo"]

--- a/test/unit/puppetlabs/services/jruby_pool_manager/jruby_service_test.clj
+++ b/test/unit/puppetlabs/services/jruby_pool_manager/jruby_service_test.clj
@@ -47,25 +47,25 @@
 
 (deftest test-error-during-init
   (testing
-   (str "If there is an exception while putting a JRubyInstance in "
+    (str "If there is an exception while putting a JRubyInstance in "
         "the pool the application should shut down.")
     (logging/with-test-logging
-     (let [got-expected-exception (atom false)]
-       (try
-         (tk-bootstrap/with-app-with-config
-          app
-          (conj jruby-testutils/default-services jruby-pooled-test-service)
-          (jruby-testutils/jruby-config
-           {:max-active-instances 1
-            :lifecycle {:initialize-pool-instance
-                        (fn [_] (throw (Exception. "42")))}})
-          (tk/run-app app))
-         (catch Exception e
-           (let [cause (stacktrace/root-cause e)]
-             (is (= (.getMessage cause) "42"))
-             (reset! got-expected-exception true))))
-       (is (true? @got-expected-exception)
-           "Did not get expected exception.")))))
+      (let [got-expected-exception (atom false)]
+        (try
+          (tk-bootstrap/with-app-with-config
+             app
+           (conj jruby-testutils/default-services jruby-pooled-test-service)
+           (jruby-testutils/jruby-config
+            {:max-active-instances 1
+             :lifecycle {:initialize-pool-instance
+                         (fn [_] (throw (Exception. "42")))}})
+           (tk/run-app app))
+          (catch Exception e
+            (let [cause (stacktrace/root-cause e)]
+              (is (= (.getMessage cause) "42"))
+              (reset! got-expected-exception true))))
+        (is (true? @got-expected-exception)
+            "Did not get expected exception.")))))
 
 (deftest test-pool-size
   (testing "The pool is created and the size is correctly reported"
@@ -195,5 +195,5 @@
   (testing (str ":borrow-timeout defaults to " jruby-core/default-borrow-timeout " milliseconds")
     (let [initial-config {:ruby-load-path ["foo"]
                           :gem-home "bar"}
-          config (jruby-core/initialize-config initial-config) ]
+          config (jruby-core/initialize-config initial-config)]
       (is (= (:borrow-timeout config) jruby-core/default-borrow-timeout)))))

--- a/test/unit/puppetlabs/services/jruby_pool_manager/jruby_testutils.clj
+++ b/test/unit/puppetlabs/services/jruby_pool_manager/jruby_testutils.clj
@@ -47,9 +47,9 @@
 
 (defn fill-drained-pool
   "Returns a list of JRubyInstances back to their pool."
-  [instance-list]
+  [pool-context instance-list]
   (doseq [instance instance-list]
-    (jruby-core/return-to-pool instance :test [])))
+    (jruby-core/return-to-pool pool-context instance :test [])))
 
 (schema/defn ^:always-validate
   drain-and-refill :- #{schema/Int}
@@ -59,7 +59,7 @@
   (let [instance-count (get-in pool-context [:config :max-active-instances])
         instances (drain-pool pool-context instance-count)
         ids (into #{} (map :id instances))]
-    (fill-drained-pool instances)
+    (fill-drained-pool pool-context instances)
     ids))
 
 (defn reduce-over-jrubies!
@@ -80,7 +80,7 @@
                       (conj acc result)))
                   []
                   (range size))]
-    (fill-drained-pool jrubies)
+    (fill-drained-pool pool-context jrubies)
     result))
 
 (defn wait-for-jrubies-from-pool-context


### PR DESCRIPTION
This new attempt defines a Clojure protocol for interacting with the JRuby pool. This allows for some polymorphism of higher-level logic around the pool itself, which is particularly important for flushing with `max-requests-per-instance` (which involves the whole pool when using the ReferencePool versus just one instance in the original implementation) and for shutting down. It also allows for cleaner, easier-to-read logic in other places (like pool filling) that differ between the backing implementations.