### PR TITLE
(maint) Use JRuby 9.2.9.0 & latest clj-parent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### 2.3.0 2019-11-04
 
 * Update JRuby to 9.2.8.0
+* Update clj-parent managed deps to 4.x series
 
 ### 2.2.0 2019-09-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 2.3.0 2019-11-04
+
+* Update JRuby to 9.2.8.0
+
 ### 2.2.0 2019-09-09
 
 * (SERVER-2193) Provide API for retrieving JRuby thread dumps

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject puppetlabs/jruby-utils "2.2.1-SNAPSHOT"
+(defproject puppetlabs/jruby-utils "2.3.0-SNAPSHOT"
   :description "A library for working with JRuby"
   :url "https://github.com/puppetlabs/jruby-utils"
   :license {:name "Apache License, Version 2.0"
@@ -23,7 +23,7 @@
                  [slingshot]
 
                  [org.yaml/snakeyaml "1.23"]
-                 [puppetlabs/jruby-deps "9.2.8.0-1"]
+                 [puppetlabs/jruby-deps "9.2.9.0-1"]
 
                  [puppetlabs/i18n]
                  [puppetlabs/kitchensink]

--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,7 @@
             :url "http://www.apache.org/licenses/LICENSE-2.0"}
 
   :min-lein-version "2.9.1"
-  :parent-project {:coords [puppetlabs/clj-parent "3.1.1"]
+  :parent-project {:coords [puppetlabs/clj-parent "4.2.6"]
                    :inherit [:managed-dependencies]}
 
   :pedantic? :abort
@@ -18,7 +18,7 @@
                  [org.clojure/java.jmx]
                  [org.clojure/tools.logging]
 
-                 [me.raynes/fs]
+                 [clj-commons/fs]
                  [prismatic/schema]
                  [slingshot]
 
@@ -28,8 +28,6 @@
                  [puppetlabs/i18n]
                  [puppetlabs/kitchensink]
                  [puppetlabs/trapperkeeper]
-                 ;; TK brings in circleci/clj-yaml that isn't compatible with Java 11
-                 [circleci/clj-yaml "0.6.0"]
                  [puppetlabs/ring-middleware]]
 
   :deploy-repositories [["releases" {:url "https://clojars.org/repo"


### PR DESCRIPTION
nb. the clj-parent bump wasn't required for 9.2.9.0 but accurately reflects the dependencies that we expect it to used with.