### PR TITLE
(SERVER-2630) Add `multithreaded` config setting

### DIFF
--- a/src/clj/puppetlabs/services/jruby_pool_manager/jruby_core.clj
+++ b/src/clj/puppetlabs/services/jruby_pool_manager/jruby_core.clj
@@ -172,6 +172,7 @@
       (update-in [:splay-instance-flush] #(if (nil? %) true %))
       (update-in [:environment-vars] #(or % {}))
       (update-in [:lifecycle] initialize-lifecycle-fns)
+      (update-in [:multithreaded] #(if (nil? %) false %))
       jruby-internal/initialize-gem-path))
 
 (schema/defn register-event-handler

--- a/src/clj/puppetlabs/services/jruby_pool_manager/jruby_schemas.clj
+++ b/src/clj/puppetlabs/services/jruby_pool_manager/jruby_schemas.clj
@@ -85,7 +85,8 @@
    :lifecycle LifecycleFns
    :environment-vars {schema/Keyword schema/Str}
    :profiling-mode SupportedJRubyProfilingModes
-   :profiler-output-file schema/Str})
+   :profiler-output-file schema/Str
+   :multithreaded schema/Bool})
 
 (def JRubyPoolAgent
   "An agent configured for use in managing JRuby pools"


### PR DESCRIPTION
This setting will eventually be used to control pool behavior when a
multithreaded environment is requested.