### PR TITLE
(SERVER-2674) Downgrade to JRuby 9.2.8.0

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -23,7 +23,7 @@
                  [slingshot]
 
                  [org.yaml/snakeyaml "1.23"]
-                 [puppetlabs/jruby-deps "9.2.9.0-1"]
+                 [puppetlabs/jruby-deps "9.2.8.0-1"]
 
                  [puppetlabs/i18n]
                  [puppetlabs/kitchensink]


### PR DESCRIPTION
Version 9.2.9.0 has an issue when first using the `system` function,
that is preventing us from installing gems under JRuby. This commit
downgrades us back to 9.2.8.0 until that bug is fixed.