### PR TITLE
(SERVER-2681) Add `availableJrubies` method

### DIFF
--- a/src/clj/puppetlabs/services/jruby_pool_manager/jruby_core.clj
+++ b/src/clj/puppetlabs/services/jruby_pool_manager/jruby_core.clj
@@ -72,7 +72,7 @@
   "Returns the number of JRubyInstances available in the pool."
   [pool :- jruby-schemas/pool-queue-type]
   {:post [(>= % 0)]}
-  (.currentSize pool))
+  (.availableJRubies pool))
 
 (schema/defn ^:always-validate
   get-instance-state :- jruby-schemas/JRubyInstanceState

--- a/src/java/com/puppetlabs/jruby_utils/pool/JRubyPool.java
+++ b/src/java/com/puppetlabs/jruby_utils/pool/JRubyPool.java
@@ -308,6 +308,11 @@ public final class JRubyPool<E> implements LockablePool<E> {
         return size;
     }
 
+    @Override
+    public int availableJRubies() {
+        return currentSize();
+    }
+
     /**
      * Lock the pool. Blocks until the lock is granted and the pool has been filled
      * back up to its full capacity

--- a/src/java/com/puppetlabs/jruby_utils/pool/LockablePool.java
+++ b/src/java/com/puppetlabs/jruby_utils/pool/LockablePool.java
@@ -122,7 +122,12 @@ public interface LockablePool<E> {
      */
     int currentSize();
 
-   /**
+    /**
+     * Returns the number of available (i.e. unused) JRuby instances in the pool.
+     */
+    int availableJRubies();
+
+    /**
     * Lock the pool. This method should make the following guarantees:
     *
     *  a) blocks until all registered elements are returned to the pool

--- a/src/java/com/puppetlabs/jruby_utils/pool/ReferencePool.java
+++ b/src/java/com/puppetlabs/jruby_utils/pool/ReferencePool.java
@@ -323,6 +323,15 @@ public final class ReferencePool<E> implements LockablePool<E> {
         return size;
     }
 
+    @Override
+    public int availableJRubies() {
+        if (this.currentBorrowCount.get() == 0) {
+            return 1;
+        } else {
+            return 0;
+        }
+    }
+
     /**
      * Lock the pool. Blocks until the lock is granted and the pool has been filled
      * back up to its full capacity


### PR DESCRIPTION
This commit adds a method for getting the number of free Jrubies in the pool.
This is the same as `currentSize` for the existing instance pool, but for the
reference pool (multithreaded) this will either be 1 (if nothing is using the
pool) or 0. This ensures that the `num-free-jrubies` metric (which uses
`free-instance-count`) is accurate for both pool types.