### PR TITLE
Revert "(SERVER-2681) Add `availableJrubies` method"

### DIFF
--- a/src/clj/puppetlabs/services/jruby_pool_manager/jruby_core.clj
+++ b/src/clj/puppetlabs/services/jruby_pool_manager/jruby_core.clj
@@ -72,7 +72,7 @@
   "Returns the number of JRubyInstances available in the pool."
   [pool :- jruby-schemas/pool-queue-type]
   {:post [(>= % 0)]}
-  (.availableJRubies pool))
+  (.currentSize pool))
 
 (schema/defn ^:always-validate
   get-instance-state :- jruby-schemas/JRubyInstanceState

--- a/src/java/com/puppetlabs/jruby_utils/pool/JRubyPool.java
+++ b/src/java/com/puppetlabs/jruby_utils/pool/JRubyPool.java
@@ -308,11 +308,6 @@ public final class JRubyPool<E> implements LockablePool<E> {
         return size;
     }
 
-    @Override
-    public int availableJRubies() {
-        return currentSize();
-    }
-
     /**
      * Lock the pool. Blocks until the lock is granted and the pool has been filled
      * back up to its full capacity

--- a/src/java/com/puppetlabs/jruby_utils/pool/LockablePool.java
+++ b/src/java/com/puppetlabs/jruby_utils/pool/LockablePool.java
@@ -122,12 +122,7 @@ public interface LockablePool<E> {
      */
     int currentSize();
 
-    /**
-     * Returns the number of available (i.e. unused) JRuby instances in the pool.
-     */
-    int availableJRubies();
-
-    /**
+   /**
     * Lock the pool. This method should make the following guarantees:
     *
     *  a) blocks until all registered elements are returned to the pool

--- a/src/java/com/puppetlabs/jruby_utils/pool/ReferencePool.java
+++ b/src/java/com/puppetlabs/jruby_utils/pool/ReferencePool.java
@@ -323,15 +323,6 @@ public final class ReferencePool<E> implements LockablePool<E> {
         return size;
     }
 
-    @Override
-    public int availableJRubies() {
-        if (this.currentBorrowCount.get() == 0) {
-            return 1;
-        } else {
-            return 0;
-        }
-    }
-
     /**
      * Lock the pool. Blocks until the lock is granted and the pool has been filled
      * back up to its full capacity


### PR DESCRIPTION
This reverts commit 1e6c95a34b6eb09d47a55af62e970177c80bcb07.
We decided to overload the `num-free-jrubies` metric to report the number of
free workers in multithreaded mode, so there is no need for a separate
`availableJRubies` method. The `currentSize` can be used.