### PR TITLE
(SERVER-2715) Record worker-id when borrowing pool resources

### DIFF
--- a/src/clj/puppetlabs/services/jruby_pool_manager/impl/jruby_events.clj
+++ b/src/clj/puppetlabs/services/jruby_pool_manager/impl/jruby_events.clj
@@ -13,18 +13,22 @@
 
 (schema/defn create-borrowed-event :- jruby-schemas/JRubyBorrowedEvent
              [requested-event :- jruby-schemas/JRubyRequestedEvent
-              instance :- jruby-schemas/JRubyBorrowResult]
+              instance :- jruby-schemas/JRubyBorrowResult
+              worker-id :- jruby-schemas/JRubyWorkerId]
              {:type :instance-borrowed
               :reason (:reason requested-event)
               :requested-event requested-event
-              :instance instance})
+              :instance instance
+              :worker-id worker-id})
 
 (schema/defn create-returned-event :- jruby-schemas/JRubyReturnedEvent
              [instance :- jruby-schemas/JRubyInstanceOrPill
-              reason :- jruby-schemas/JRubyEventReason]
+              reason :- jruby-schemas/JRubyEventReason
+              worker-id :- jruby-schemas/JRubyWorkerId]
              {:type :instance-returned
               :reason reason
-              :instance instance})
+              :instance instance
+              :worker-id worker-id})
 
 (schema/defn create-lock-requested-event :- jruby-schemas/JRubyLockRequestedEvent
              [reason :- jruby-schemas/JRubyEventReason]
@@ -59,14 +63,16 @@
 (schema/defn instance-borrowed :- jruby-schemas/JRubyBorrowedEvent
              [event-callbacks :- [IFn]
               requested-event :- jruby-schemas/JRubyRequestedEvent
-              instance :- jruby-schemas/JRubyBorrowResult]
-             (notify-event-listeners event-callbacks (create-borrowed-event requested-event instance)))
+              instance :- jruby-schemas/JRubyBorrowResult
+              worker-id :- jruby-schemas/JRubyWorkerId]
+             (notify-event-listeners event-callbacks (create-borrowed-event requested-event instance worker-id)))
 
 (schema/defn instance-returned :- jruby-schemas/JRubyReturnedEvent
              [event-callbacks :- [IFn]
               instance :- jruby-schemas/JRubyInstanceOrPill
-              reason :- jruby-schemas/JRubyEventReason]
-             (notify-event-listeners event-callbacks (create-returned-event instance reason)))
+              reason :- jruby-schemas/JRubyEventReason
+              worker-id :- jruby-schemas/JRubyWorkerId]
+             (notify-event-listeners event-callbacks (create-returned-event instance reason worker-id)))
 
 (schema/defn lock-requested :- jruby-schemas/JRubyLockRequestedEvent
              [event-callbacks :- [IFn]

--- a/src/clj/puppetlabs/services/jruby_pool_manager/jruby_core.clj
+++ b/src/clj/puppetlabs/services/jruby_pool_manager/jruby_core.clj
@@ -200,8 +200,8 @@
    reason :- schema/Any
    event-callbacks :- [IFn]]
   (let [requested-event (jruby-events/instance-requested event-callbacks reason)
-        instance (pool-protocol/borrow pool-context)]
-    (jruby-events/instance-borrowed event-callbacks requested-event instance)
+        [instance worker-id] (pool-protocol/borrow pool-context)]
+    (jruby-events/instance-borrowed event-callbacks requested-event instance worker-id)
     instance))
 
 ;; TODO: consider adding a second arity that allows for passing in a
@@ -219,10 +219,10 @@
    event-callbacks :- [IFn]]
   (let [timeout (get-in pool-context [:config :borrow-timeout])
         requested-event (jruby-events/instance-requested event-callbacks reason)
-        instance (pool-protocol/borrow-with-timeout
-                   pool-context
-                   timeout)]
-    (jruby-events/instance-borrowed event-callbacks requested-event instance)
+        [instance worker-id] (pool-protocol/borrow-with-timeout
+                          pool-context
+                          timeout)]
+    (jruby-events/instance-borrowed event-callbacks requested-event instance worker-id)
     instance))
 
 (schema/defn ^:always-validate
@@ -232,8 +232,8 @@
    instance :- jruby-schemas/JRubyInstanceOrPill
    reason :- schema/Any
    event-callbacks :- [IFn]]
-  (jruby-events/instance-returned event-callbacks instance reason)
-  (pool-protocol/return pool-context instance))
+  (let [worker-id (pool-protocol/return pool-context instance)]
+    (jruby-events/instance-returned event-callbacks instance reason worker-id)))
 
 (schema/defn ^:always-validate
   flush-pool!

--- a/src/clj/puppetlabs/services/jruby_pool_manager/jruby_core.clj
+++ b/src/clj/puppetlabs/services/jruby_pool_manager/jruby_core.clj
@@ -220,8 +220,8 @@
   (let [timeout (get-in pool-context [:config :borrow-timeout])
         requested-event (jruby-events/instance-requested event-callbacks reason)
         [instance worker-id] (pool-protocol/borrow-with-timeout
-                          pool-context
-                          timeout)]
+                               pool-context
+                               timeout)]
     (jruby-events/instance-borrowed event-callbacks requested-event instance worker-id)
     instance))
 

--- a/src/clj/puppetlabs/services/jruby_pool_manager/jruby_schemas.clj
+++ b/src/clj/puppetlabs/services/jruby_pool_manager/jruby_schemas.clj
@@ -198,6 +198,10 @@
                         shutdown-poison-pill?
                         jruby-instance?)))
 
+(def JRubyWorkerId
+  (schema/pred (some-fn nil?
+                        (partial instance? Long))))
+
 (def JRubyMain
   (schema/pred jruby-main-instance?))
 
@@ -261,12 +265,14 @@
   {:type (schema/eq :instance-borrowed)
    :reason JRubyEventReason
    :requested-event JRubyRequestedEvent
-   :instance JRubyBorrowResult})
+   :instance JRubyBorrowResult
+   :worker-id JRubyWorkerId})
 
 (def JRubyReturnedEvent
   {:type (schema/eq :instance-returned)
    :reason JRubyEventReason
-   :instance JRubyInstanceOrPill})
+   :instance JRubyInstanceOrPill
+   :worker-id JRubyWorkerId})
 
 (def JRubyLockRequestedEvent
   {:type (schema/eq :lock-requested)

--- a/src/clj/puppetlabs/services/protocols/jruby_pool.clj
+++ b/src/clj/puppetlabs/services/protocols/jruby_pool.clj
@@ -25,18 +25,20 @@
 
   (borrow
     [pool-context]
-    "Returns a reference to a JRuby instance. Will block if the pool is locked or no instances
-    are available.")
+    "Returns a reference to a JRuby instance and a worker id (instance id or thread id).
+    Will block if the pool is locked or no instances are available.")
 
 
   (borrow-with-timeout
     [pool-context timeout]
-    "Returns a reference to a JRuby instance. Will block if the pool is locked or no instances
-    are available, timing out when the supplied number of milliseconds has elapsed.")
+    "Returns a reference to a JRuby instance and a worker id (instance id or thread id).
+    Will block if the pool is locked or no instances are available, timing out when the
+    supplied number of milliseconds has elapsed.")
 
   (return
     [pool-context instance]
-    "Releases a held reference to a JRuby instance back to the pool. If `max-requests-per-instance`
+    "Releases a held reference to a JRuby instance back to the pool and returns the worker id
+    (instance id or thread id) for the thing being returned. If `max-requests-per-instance`
     is configured and has been reached for this instance, this function will trigger a flush of
     the instance. Note that when using the ReferencePool, this will also cause the pool to be locked.
 

--- a/test/unit/puppetlabs/services/jruby_pool_manager/jruby_pool_test.clj
+++ b/test/unit/puppetlabs/services/jruby_pool_manager/jruby_pool_test.clj
@@ -220,6 +220,16 @@
    (jruby-testutils/jruby-config {:max-active-instances max-instances
                                   :max-borrows-per-instance max-borrows})))
 
+(deftest worker-id-persists
+  (testing "worker id is the same at borrow time and return time"
+    (jruby-testutils/with-pool-context
+      pool-context
+      jruby-testutils/default-services
+      (jruby-test-config 2)
+      (let [[instance borrowed-id] (pool-protocol/borrow pool-context)
+            returned-id (pool-protocol/return pool-context instance)]
+        (is (= borrowed-id returned-id))))))
+
 (deftest splay-jruby-instance-flushing
   (testing "Disabled JRuby instance splaying -"
     (jruby-testutils/with-pool-context

--- a/test/unit/puppetlabs/services/jruby_pool_manager/jruby_ref_pool_test.clj
+++ b/test/unit/puppetlabs/services/jruby_pool_manager/jruby_ref_pool_test.clj
@@ -23,6 +23,18 @@
                                           :max-borrows-per-instance max-borrows}
                                          options))))
 
+(deftest worker-id-persists
+  (testing "worker id is the same at borrow time and return time"
+    (jruby-testutils/with-pool-context
+      pool-context
+      jruby-testutils/default-services
+      (jruby-test-config 2)
+      (let [[instance borrowed-id] (pool-protocol/borrow pool-context)
+            returned-id (pool-protocol/return pool-context instance)]
+        (is (= (.getId (Thread/currentThread)) borrowed-id))
+        (is (= (.getId (Thread/currentThread)) returned-id))
+        (is (= borrowed-id returned-id))))))
+
 (deftest borrow-while-no-instances-available-test
   (testing "when all instances are in use, borrow blocks until an instance becomes available"
     (let [pool-size 2]
@@ -135,8 +147,8 @@
       (jruby-test-config 1 2 {:flush-timeout 1})
       ;; Borrow instance1 so we can trigger a refresh when we return it
       ;; Borrow instance2 to prevent lock from being acquired when we return instance1
-      (let [instance1 (pool-protocol/borrow pool-context)
-            instance2 (pool-protocol/borrow pool-context)
+      (let [instance1 (first (pool-protocol/borrow pool-context))
+            instance2 (first (pool-protocol/borrow pool-context))
             flush-complete (add-watch-for-flush-complete pool-context)]
         (logutils/with-test-logging
           ;; Return to trigger flush, which should block since instance2 is still borrowed
@@ -156,7 +168,7 @@
       jruby-testutils/default-services
       (jruby-test-config 2 1 {:flush-timeout 0})
       ;; Borrow an instance so that the lock can't be acquired
-      (let [instance (pool-protocol/borrow pool-context)]
+      (let [instance (first (pool-protocol/borrow pool-context))]
         (is (thrown+? [:kind :puppetlabs.services.jruby-pool-manager.impl.jruby-internal/jruby-lock-timeout
                        :msg "An attempt to lock the JRubyPool failed with a timeout"]
                       (pool-protocol/flush-pool pool-context)))
@@ -190,7 +202,7 @@
           pool (jruby-core/get-pool pool-context)
           _ (jruby-testutils/wait-for-jrubies-from-pool-context pool-context)
           ;; Set up test
-          instance (pool-protocol/borrow pool-context)
+          instance (first (pool-protocol/borrow pool-context))
           shutdown-complete? (promise)
           _ (future
               (pool-protocol/shutdown pool-context)

--- a/test/unit/puppetlabs/services/jruby_pool_manager/jruby_ref_pool_test.clj
+++ b/test/unit/puppetlabs/services/jruby_pool_manager/jruby_ref_pool_test.clj
@@ -32,8 +32,7 @@
       (let [[instance borrowed-id] (pool-protocol/borrow pool-context)
             returned-id (pool-protocol/return pool-context instance)]
         (is (= (.getId (Thread/currentThread)) borrowed-id))
-        (is (= (.getId (Thread/currentThread)) returned-id))
-        (is (= borrowed-id returned-id))))))
+        (is (= (.getId (Thread/currentThread)) returned-id))))))
 
 (deftest borrow-while-no-instances-available-test
   (testing "when all instances are in use, borrow blocks until an instance becomes available"


### PR DESCRIPTION
This commit adds a `:worker-id` event field to be sent to the metrics service.
For the instance pool, this is the instance id we've already been using. For
the new reference pool, this is the thread id. This will allow us to reason
about pool usage in similar ways for both pool types.