### PR TITLE
(SERVER-2679) Ensure return callback runs before actual return

### DIFF
--- a/src/clj/puppetlabs/services/jruby_pool_manager/impl/instance_pool.clj
+++ b/src/clj/puppetlabs/services/jruby_pool_manager/impl/instance_pool.clj
@@ -34,17 +34,19 @@
     (let [pool (jruby-internal/get-pool pool-context)]
       (.unlock pool)))
 
+  (worker-id
+    [pool-context instance]
+    (:id instance))
+
   (borrow
     [pool-context]
-    (let [instance (jruby-internal/borrow-from-pool pool-context)
-          worker-id (:id instance)]
-      [instance worker-id]))
+    (let [instance (jruby-internal/borrow-from-pool pool-context)]
+      [instance (pool-protocol/worker-id pool-context instance)]))
 
   (borrow-with-timeout
     [pool-context timeout]
-    (let [instance (jruby-internal/borrow-from-pool-with-timeout pool-context timeout)
-          worker-id (:id instance)]
-      [instance worker-id]))
+    (let [instance (jruby-internal/borrow-from-pool-with-timeout pool-context timeout)]
+      [instance (pool-protocol/worker-id pool-context instance)]))
 
   (return
     [pool-context instance]
@@ -53,7 +55,7 @@
                              #(update-in % [:borrow-count] inc))
             {:keys [initial-borrows max-borrows pool]} (:internal instance)
             borrow-limit (or initial-borrows max-borrows)
-            worker-id (:id instance)]
+            worker-id (pool-protocol/worker-id pool-context instance)]
         (if (and (pos? borrow-limit)
                  (>= (:borrow-count new-state) borrow-limit))
           (do

--- a/src/clj/puppetlabs/services/jruby_pool_manager/impl/reference_pool.clj
+++ b/src/clj/puppetlabs/services/jruby_pool_manager/impl/reference_pool.clj
@@ -106,17 +106,19 @@
     (let [pool (jruby-internal/get-pool pool-context)]
       (.unlock pool)))
 
+  (worker-id
+    [pool-context instance]
+    (.getId (Thread/currentThread)))
+
   (borrow
     [pool-context]
-    (let [instance (jruby-internal/borrow-from-pool pool-context)
-          worker-id (.getId (Thread/currentThread))]
-      [instance worker-id]))
+    (let [instance (jruby-internal/borrow-from-pool pool-context)]
+      [instance (pool-protocol/worker-id pool-context instance)]))
 
   (borrow-with-timeout
     [pool-context timeout]
-    (let [instance (jruby-internal/borrow-from-pool-with-timeout pool-context timeout)
-          worker-id (.getId (Thread/currentThread))]
-      [instance worker-id]))
+    (let [instance (jruby-internal/borrow-from-pool-with-timeout pool-context timeout)]
+      [instance (pool-protocol/worker-id pool-context instance)]))
 
   (return
     [pool-context instance]
@@ -131,7 +133,7 @@
           (jruby-agents/send-agent modify-instance-agent
                                    #(flush-if-at-max-borrows pool-context instance)))
         ;; Return the worker-id, to be used in metrics and event logging
-        (.getId (Thread/currentThread)))))
+        (pool-protocol/worker-id pool-context instance))))
 
   (flush-pool
     [pool-context]

--- a/src/clj/puppetlabs/services/jruby_pool_manager/jruby_core.clj
+++ b/src/clj/puppetlabs/services/jruby_pool_manager/jruby_core.clj
@@ -232,8 +232,9 @@
    instance :- jruby-schemas/JRubyInstanceOrPill
    reason :- schema/Any
    event-callbacks :- [IFn]]
-  (let [worker-id (pool-protocol/return pool-context instance)]
-    (jruby-events/instance-returned event-callbacks instance reason worker-id)))
+  (let [worker-id (pool-protocol/worker-id pool-context instance)]
+    (jruby-events/instance-returned event-callbacks instance reason worker-id)
+    (pool-protocol/return pool-context instance)))
 
 (schema/defn ^:always-validate
   flush-pool!

--- a/src/clj/puppetlabs/services/protocols/jruby_pool.clj
+++ b/src/clj/puppetlabs/services/protocols/jruby_pool.clj
@@ -23,6 +23,10 @@
     [pool-context]
     "Unlocks the JRuby pool, allowing borrows to proceed.")
 
+  (worker-id
+    [pool-context instance]
+    "Returns the worker id for given instance (instance id or thread id).")
+
   (borrow
     [pool-context]
     "Returns a reference to a JRuby instance and a worker id (instance id or thread id).


### PR DESCRIPTION
This commit puts the `instance-returned` callback before the actual `return`
again in the public-facting `return-to-pool` method. Previously, if a request
was waiting for a new instance, calling `return` first could trigger a new
borrow so quickly that the borrow event callback would trigger before the return
event callback. For the instance pool, because instances ids are reused, instead
of 1. removing the instance from the `borrowed-instances` metric and then 2.
adding it back with the new borrow event, we ended up 1. updating the
`borrowed-instances` with the new event and then 2. removing the instance from
`borrowed-instances`, which caused the metric to lose track of a whole instance.