### PR TITLE
(SERVER-2660) Update JRuby to 9.2.11.1

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -23,7 +23,7 @@
                  [slingshot]
 
                  [org.yaml/snakeyaml "1.23"]
-                 [puppetlabs/jruby-deps "9.2.11.0-1"]
+                 [puppetlabs/jruby-deps "9.2.11.1-1"]
 
                  [puppetlabs/i18n]
                  [puppetlabs/kitchensink]


### PR DESCRIPTION
This update contains a fix for a sprintf buffer bug.