### PR TITLE
(SERVER-2793) Roll back JRuby to 9.2.8.0

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -23,7 +23,7 @@
                  [slingshot]
 
                  [org.yaml/snakeyaml "1.23"]
-                 [puppetlabs/jruby-deps "9.2.11.1-1"]
+                 [puppetlabs/jruby-deps "9.2.8.0-2"]
 
                  [puppetlabs/i18n]
                  [puppetlabs/kitchensink]


### PR DESCRIPTION
We discovered a potential bug in JRuby 9.2.11.1 that might be causing
StackOverflow errors that put the server into an unrecoverable state.
We're rolling back JRuby in preparation for a release, to be safe.