### PR TITLE
(SERVER-2793) Bump JRuby 9.2.11.1 to again

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -23,7 +23,7 @@
                  [slingshot]
 
                  [org.yaml/snakeyaml "1.23"]
-                 [puppetlabs/jruby-deps "9.2.8.0-2"]
+                 [puppetlabs/jruby-deps "9.2.11.1-1"]
 
                  [puppetlabs/i18n]
                  [puppetlabs/kitchensink]


### PR DESCRIPTION
This reverts commit b5ffb91f8bbc27ad83aadedc6e547756218398c4.