### PR TITLE
(SERVER-2793) Disable invokedynamic for yields

### DIFF
--- a/src/clj/puppetlabs/services/jruby_pool_manager/impl/jruby_internal.clj
+++ b/src/clj/puppetlabs/services/jruby_pool_manager/impl/jruby_internal.clj
@@ -101,6 +101,7 @@
       (.setCompileMode (get-compile-mode compile-mode)))
     (set-ruby-encoding KCode/UTF8 jruby)
     (setup-profiling jruby profiler-output-file profiling-mode)
+    (System/setProperty "jruby.invokedynamic.yield" "false")
     (initialize-scripting-container-fn jruby config)))
 
 (schema/defn ^:always-validate empty-scripting-container :- ScriptingContainer


### PR DESCRIPTION
This is on by default as of JRuby 9.2.11.0. It appears to be related to
stack overflows that we've started seeing, so turn it off for now.