### PR TITLE
(SERVER-1243) Error when configured pool size is less than 1

### DIFF
--- a/src/clj/puppetlabs/services/jruby_pool_manager/impl/jruby_internal.clj
+++ b/src/clj/puppetlabs/services/jruby_pool_manager/impl/jruby_internal.clj
@@ -184,6 +184,10 @@
   [config :- jruby-schemas/JRubyConfig]
   (let [multithreaded (:multithreaded config)
         size (:max-active-instances config)]
+    (when (< size 1)
+      (throw (Exception.
+              (i18n/trs "Invalid pool size: {0}. Pool size must be at least 1."
+                        size))))
     (if multithreaded
       {:pool (instantiate-reference-pool size)
        :size 1}


### PR DESCRIPTION
It is not meaningful to create a JRuby pool with less than one instance,
because then any attempt to borrow an instance will hang. This commit
causes an error to be thrown if the user attempts to configure
`max-active-instances` to a value less than 1.