### PR TITLE
(SERVER-3007) Update Jruby to 9.2.17.0

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,7 @@
             :url "http://www.apache.org/licenses/LICENSE-2.0"}
 
   :min-lein-version "2.9.1"
-  :parent-project {:coords [puppetlabs/clj-parent "4.6.0"]
+  :parent-project {:coords [puppetlabs/clj-parent "4.6.20"]
                    :inherit [:managed-dependencies]}
 
   :pedantic? :abort
@@ -22,8 +22,7 @@
                  [prismatic/schema]
                  [slingshot]
 
-                 [org.yaml/snakeyaml "1.23"]
-                 [puppetlabs/jruby-deps "9.2.14.0-1"]
+                 [puppetlabs/jruby-deps "9.2.17.0-1"]
 
                  [puppetlabs/i18n]
                  [puppetlabs/kitchensink]


### PR DESCRIPTION
This is a maintenance update. Newer versions of clj-parent pull in a new
enough snakeyaml that we no longer need to pin it here.