### PR TITLE
(maint) Bump jruby-deps to 9.3.4.0-2

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -22,7 +22,7 @@
                  [prismatic/schema]
                  [slingshot]
 
-                 [puppetlabs/jruby-deps "9.3.4.0-1"]
+                 [puppetlabs/jruby-deps "9.3.4.0-2"]
 
                  [puppetlabs/i18n]
                  [puppetlabs/kitchensink]


### PR DESCRIPTION
This unpins a dependency that was causing pedantic conflicts.