### PR TITLE
(PE-36375) Take up JRuby 9.4.3

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,7 @@
             :url "http://www.apache.org/licenses/LICENSE-2.0"}
 
   :min-lein-version "2.9.1"
-  :parent-project {:coords [puppetlabs/clj-parent "4.10.1"]
+  :parent-project {:coords [puppetlabs/clj-parent "7.2.3"]
                    :inherit [:managed-dependencies]}
 
   :pedantic? :abort
@@ -42,7 +42,7 @@
 
   :profiles {:dev {:dependencies  [[puppetlabs/kitchensink :classifier "test" :scope "test"]
                                    [puppetlabs/trapperkeeper :classifier "test" :scope "test"]
-                                   [org.bouncycastle/bcpkix-jdk15on]
+                                   [org.bouncycastle/bcpkix-jdk18on]
                                    [org.tcrawley/dynapath]]
                    :jvm-opts ["-Djruby.logger.class=com.puppetlabs.jruby_utils.jruby.Slf4jLogger"
                               "-Xms1G"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject puppetlabs/jruby-utils "5.0.1-SNAPSHOT"
+(defproject puppetlabs/jruby-utils "5.1.0-SNAPSHOT"
   :description "A library for working with JRuby"
   :url "https://github.com/puppetlabs/jruby-utils"
   :license {:name "Apache License, Version 2.0"
@@ -22,7 +22,7 @@
                  [prismatic/schema]
                  [slingshot]
 
-                 [puppetlabs/jruby-deps "9.4.2.0-1"]
+                 [puppetlabs/jruby-deps "9.4.3.0-1"]
 
                  [puppetlabs/i18n]
                  [puppetlabs/kitchensink]
@@ -44,9 +44,16 @@
                                    [puppetlabs/trapperkeeper :classifier "test" :scope "test"]
                                    [org.bouncycastle/bcpkix-jdk18on]
                                    [org.tcrawley/dynapath]]
-                   :jvm-opts ["-Djruby.logger.class=com.puppetlabs.jruby_utils.jruby.Slf4jLogger"
-                              "-Xms1G"
-                              "-Xmx2G"]}
+                   :jvm-opts ~(let [version (System/getProperty "java.specification.version")
+                                    [major minor _] (clojure.string/split version #"\.")]
+                                (concat
+                                  ["-Djruby.logger.class=com.puppetlabs.jruby_utils.jruby.Slf4jLogger"
+                                   "-XX:+UseG1GC"
+                                   "-Xms1G"
+                                   "-Xmx2G"]
+                                  (if (= 17 (java.lang.Integer/parseInt major))
+                                    ["--add-opens" "java.base/sun.nio.ch=ALL-UNNAMED" "--add-opens" "java.base/java.io=ALL-UNNAMED"]
+                                    [])))}
              :testutils {:source-paths ^:replace ["test/unit" "test/integration"]}}
 
   :plugins [[lein-parent "0.3.7"]

--- a/test/unit/puppetlabs/services/jruby_pool_manager/jruby_core_test.clj
+++ b/test/unit/puppetlabs/services/jruby_pool_manager/jruby_core_test.clj
@@ -84,28 +84,30 @@
         (is (= 0 exit-code))
         ; The choice of json is arbitrary, just need something to scan for
         (is (re-find #"\bjson\b" out))))
-    (testing "irb"
-      (let [m (capture-out
-                (with-stdin-str "puts %{HELLO}\n"
-                  (jruby-core/cli-run! min-config "irb" ["-f"])))
-            {:keys [return out]} m
-            exit-code (.getStatus return)]
-        (is (= 0 exit-code))
-        (is (re-find #"\nHELLO\n" out)))
-      (let [m (capture-out
-                (with-stdin-str "Kernel.exit(42)\n"
-                  (jruby-core/cli-run! min-config "irb" ["-f"])))
-            {:keys [return _]} m
-            exit-code (.getStatus return)]
-        (is (= 42 exit-code))))
-    (testing "irb with -r foo"
-      (let [m (capture-out
-                (with-stdin-str "puts %{#{foo}}\n"
-                  (jruby-core/cli-run! min-config "irb" ["-r" "foo" "-f"])))
-            {:keys [return out]} m
-            exit-code (.getStatus return)]
-        (is (= 0 exit-code))
-        (is (re-find #"bar" out))))
+    ;; IRB testing does not work on *nix based systems until a version
+    ;; of io/console >= 0.6.0 is included in JRuby
+    ; (testing "irb"
+    ;   (let [m (capture-out
+    ;             (with-stdin-str "puts %{HELLO}\n"
+    ;               (jruby-core/cli-run! min-config "irb" ["-f"])))
+    ;         {:keys [return out]} m
+    ;         exit-code (.getStatus return)]
+    ;     (is (= 0 exit-code))
+    ;     (is (re-find #"\nHELLO\n" out)))
+    ;   (let [m (capture-out
+    ;             (with-stdin-str "Kernel.exit(42)\n"
+    ;               (jruby-core/cli-run! min-config "irb" ["-f"])))
+    ;         {:keys [return _]} m
+    ;         exit-code (.getStatus return)]
+    ;     (is (= 42 exit-code))))
+    ; (testing "irb with -r foo"
+    ;   (let [m (capture-out
+    ;             (with-stdin-str "puts %{#{foo}}\n"
+    ;               (jruby-core/cli-run! min-config "irb" ["-r" "foo" "-f"])))
+    ;         {:keys [return out]} m
+    ;         exit-code (.getStatus return)]
+    ;     (is (= 0 exit-code))
+    ;     (is (re-find #"bar" out))))
     (testing "non existing subcommand returns nil"
       (logutils/with-test-logging
         (is (nil? (jruby-core/cli-run! min-config "doesnotexist" [])))))))


### PR DESCRIPTION
individual commit messages:
----
c7319f1 (maint) Update clj-parent

The current version of clj-parent is several major versions behind the
version of clj-parent that this version of jruby-utils will be in.

----
cbbab26 (PE-36375) Take up JRuby 9.4.3

When we upgraded to JRuby 9.4 we broke our IRB testing because of an
issue in JRuby and the io/console library. The FFI that io/console
integrates with has changed and the 'path' variable no longer exists on
linux based consoles unless the IO is backed by an actual file.[1]

This fails in our testing where we stub stdin & stdout with essentially
a StringIO object, but does not fail when running IRB normally with an
actual terminal attached.

This should have a known issue written about it, however I know of no
use case where a user would write a Puppet extension that needed an
interactive console.

This bug was also released in Puppet Server 8.0 and thus far we have not
heard of issues regarding it so we have anecdotal data that Puppet users
are not needing programmatic access to an interactive console via JRuby.

The fix for this issue has been committed[2] to the io/console repository
but has not been released yet. Once io/console >= 0.6.0 has been
released and JRuby has taken it up, our test changes and any known
issues around this should be resolved.

1. https://github.com/jruby/jruby/issues/7727
2. https://github.com/ruby/io-console/commit/f1bb90fe01b6d9b5db68437ffd4acf7c47695168